### PR TITLE
fix(lexer): correct pipe-array regex precedence

### DIFF
--- a/src/__tests__/Lexer.test.ts
+++ b/src/__tests__/Lexer.test.ts
@@ -1,0 +1,31 @@
+import { RomlFile } from '../file/RomlFile';
+
+describe('Lexer regressions', () => {
+  describe('pipe-array regex precedence', () => {
+    // Regression: RomlLexer's pipe-array pattern was
+    //   /^(.+?)\|\|(.*)|\|$/
+    // which due to alternation precedence meant
+    //   (^(.+?)\|\|(.*)) | (\|$)
+    // so a line ending in a single `|` matched the trailing alternative,
+    // capture groups [1]/[2] became undefined, and the very next line
+    // accessed `.includes('||')` on undefined and crashed with a TypeError.
+    it('does not surface a TypeError for a line ending in a single pipe', () => {
+      expect(() => RomlFile.romlToJson('~ROML~\nfoo|')).not.toThrow(
+        /Cannot read properties of undefined/
+      );
+    });
+
+    it('treats an unparseable trailing-pipe line as no-op (silent drop)', () => {
+      // After the fix, the line matches no syntax style and is dropped,
+      // matching existing behavior for any unrecognized line.
+      expect(RomlFile.romlToJson('~ROML~\nfoo|')).toEqual({});
+    });
+
+    it('still parses a well-formed pipe array', () => {
+      // Sanity: the fix must not regress the legitimate pipe-array case.
+      expect(RomlFile.romlToJson('~ROML~\nitems||a||b||c||')).toEqual({
+        items: ['a', 'b', 'c'],
+      });
+    });
+  });
+});

--- a/src/lexer/RomlLexer.ts
+++ b/src/lexer/RomlLexer.ts
@@ -503,7 +503,7 @@ export class RomlLexer {
     }
 
     // Parse pipe arrays: key||item1||item2|| (content between pipes can be empty)
-    const pipeArrayMatch = line.match(/^(.+?)\|\|(.*)|\|$/);
+    const pipeArrayMatch = line.match(/^(.+?)\|\|(.*)\|\|$/);
     if (pipeArrayMatch) {
       const key = pipeArrayMatch[1];
       const value = pipeArrayMatch[2];


### PR DESCRIPTION
## Summary

Fixes a `TypeError` that surfaced from the lexer on any input ending in a single `|`.

The pipe-array pattern in `src/lexer/RomlLexer.ts` was

```js
const pipeArrayMatch = line.match(/^(.+?)\|\|(.*)|\|$/);
```

which due to alternation precedence parses as

```
(^(.+?)\|\|(.*)) | (\|$)
```

Lines like `foo|` matched the trailing alternative with `undefined` capture groups, then the next access of `.includes('||')` on undefined threw, surfaced to callers as:

```
Parse validation failed: Cannot read properties of undefined (reading 'includes')
```

Fix is one character: require trailing `||` so only well-formed pipe arrays match. Lines like `foo|` now fall through and are silently dropped, matching existing behavior for any unrecognized line.

## Failing test (added in this PR)

```ts
// src/__tests__/Lexer.test.ts
it('does not surface a TypeError for a line ending in a single pipe', () => {
  expect(() => RomlFile.romlToJson('~ROML~\nfoo|')).not.toThrow(
    /Cannot read properties of undefined/
  );
});
it('treats an unparseable trailing-pipe line as no-op (silent drop)', () => {
  expect(RomlFile.romlToJson('~ROML~\nfoo|')).toEqual({});
});
it('still parses a well-formed pipe array', () => {
  expect(RomlFile.romlToJson('~ROML~\nitems||a||b||c||')).toEqual({
    items: ['a', 'b', 'c'],
  });
});
```

Before fix: 2 of 3 fail with the TypeError. After fix: all 3 pass.

## BC break

No.

## Test plan

- [x] `npm install && npm run build && npm run lint && npm test` — 239 tests pass (236 + 3 new), lint and build clean.
- [x] CLI smoke test: `echo '{"x":1,"y":[1,2,3]}' | node dist/cli.js encode | node dist/cli.js decode` round-trips identical.
- [x] Manual probe: `RomlFile.romlToJson('~ROML~\nfoo|')` no longer throws with `Cannot read properties of undefined`.

https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV)_