### PR TITLE
fix(format): rename synthetic root wrappers to avoid user-key collision

### DIFF
--- a/src/RomlConverter.ts
+++ b/src/RomlConverter.ts
@@ -4,6 +4,8 @@ import {
   EMPTY_DOCUMENT_FEATURES,
   EMPTY_LINE_FEATURES,
   MetaTags,
+  SYNTHETIC_ITEMS_KEY,
+  SYNTHETIC_VALUE_KEY,
 } from './types.js';
 import { objectContainsPrimes, containsPrime } from './utils/primeUtils.js';
 
@@ -211,9 +213,9 @@ export class RomlConverter {
     let processData: Record<string, unknown>;
 
     if (inputType === 'array') {
-      processData = { _items: data };
+      processData = { [SYNTHETIC_ITEMS_KEY]: data };
     } else if (inputType === 'primitive') {
-      processData = { _value: data };
+      processData = { [SYNTHETIC_VALUE_KEY]: data };
     } else {
       processData = data as Record<string, unknown>;
     }
@@ -626,7 +628,7 @@ export class RomlConverter {
   }
 
   private isSyntheticWrapperKey(key: string): boolean {
-    return key === '_items' || key === '_value';
+    return key === SYNTHETIC_ITEMS_KEY || key === SYNTHETIC_VALUE_KEY;
   }
 
   /**
@@ -645,7 +647,7 @@ export class RomlConverter {
    */
   private objectContainsPrimesExcludingWrapperKeys(data: Record<string, unknown>): boolean {
     for (const [key, value] of Object.entries(data)) {
-      if (key === '_items' || key === '_value') {
+      if (key === SYNTHETIC_ITEMS_KEY || key === SYNTHETIC_VALUE_KEY) {
         // For wrapper keys, check items that would actually generate prime prefixes
         if (Array.isArray(value)) {
           // Check if this array uses structured format (which generates prefixes)

--- a/src/__tests__/WrapperKeyCollision.test.ts
+++ b/src/__tests__/WrapperKeyCollision.test.ts
@@ -1,0 +1,42 @@
+import { RomlFile } from '../file/RomlFile';
+
+describe('Synthetic wrapper-key collision', () => {
+  // Regression: top-level non-objects are wrapped as { _items: [...] } or
+  // { _value: x } before encoding, then unwrapped by the parser. Those names
+  // were valid user keys, so a user object whose root key happened to be
+  // `_items` or `_value` would silently lose its envelope on round-trip:
+  //   { "_items": [1,2,3] } -> ROML -> [1,2,3]
+  //   { "_value": 42 }      -> ROML -> 42
+
+  it('round-trips an object whose root key is _items', () => {
+    const input = { _items: [1, 2, 3] };
+    expect(RomlFile.romlToJson(RomlFile.jsonToRoml(input))).toEqual(input);
+  });
+
+  it('round-trips an object whose root key is _value', () => {
+    const input = { _value: 42 };
+    expect(RomlFile.romlToJson(RomlFile.jsonToRoml(input))).toEqual(input);
+  });
+
+  it('round-trips an object whose root key is _value with a string', () => {
+    const input = { _value: 'hello' };
+    expect(RomlFile.romlToJson(RomlFile.jsonToRoml(input))).toEqual(input);
+  });
+
+  it('round-trips an object containing both _items and _value as keys', () => {
+    const input = { _items: 'x', _value: 'y' };
+    expect(RomlFile.romlToJson(RomlFile.jsonToRoml(input))).toEqual(input);
+  });
+
+  it('still round-trips a true top-level array (the synthetic-wrap case)', () => {
+    const input = [1, 2, 3];
+    expect(RomlFile.romlToJson(RomlFile.jsonToRoml(input))).toEqual(input);
+  });
+
+  it('still round-trips a true top-level primitive', () => {
+    expect(RomlFile.romlToJson(RomlFile.jsonToRoml(42))).toEqual(42);
+    expect(RomlFile.romlToJson(RomlFile.jsonToRoml('hi'))).toEqual('hi');
+    expect(RomlFile.romlToJson(RomlFile.jsonToRoml(true))).toEqual(true);
+    expect(RomlFile.romlToJson(RomlFile.jsonToRoml(null))).toEqual(null);
+  });
+});

--- a/src/lexer/RomlLexer.ts
+++ b/src/lexer/RomlLexer.ts
@@ -1,3 +1,5 @@
+import { SYNTHETIC_ITEMS_KEY, SYNTHETIC_VALUE_KEY } from '../types.js';
+
 /**
  * Unescape string from ROML format - convert escape sequences back to actual characters
  */
@@ -534,7 +536,7 @@ export class RomlLexer {
           : this.parseSpecialValue(value);
 
         // For wrapper keys, single values should still be arrays
-        if (key === '_items' || key === '_value') {
+        if (key === SYNTHETIC_ITEMS_KEY || key === SYNTHETIC_VALUE_KEY) {
           return [key, [singleValue], 'PIPES'];
         }
 

--- a/src/parser/RomlParser.ts
+++ b/src/parser/RomlParser.ts
@@ -1,5 +1,5 @@
 import { RomlToken } from '../lexer/RomlLexer.js';
-import { MetaTags } from '../types.js';
+import { MetaTags, SYNTHETIC_ITEMS_KEY, SYNTHETIC_VALUE_KEY } from '../types.js';
 
 export interface RomlMetadata {
   checksum: string;
@@ -333,14 +333,18 @@ export class RomlParser {
   private unwrapSyntheticObject(data: Record<string, any>): any {
     const keys = Object.keys(data);
 
-    // Check for array wrapper: {"_items": [...]}
-    if (keys.length === 1 && keys[0] === '_items' && Array.isArray(data._items)) {
-      return data._items;
+    // Check for array wrapper: {"__roml_items__": [...]}
+    if (
+      keys.length === 1 &&
+      keys[0] === SYNTHETIC_ITEMS_KEY &&
+      Array.isArray(data[SYNTHETIC_ITEMS_KEY])
+    ) {
+      return data[SYNTHETIC_ITEMS_KEY];
     }
 
-    // Check for primitive wrapper: {"_value": ...}
-    if (keys.length === 1 && keys[0] === '_value') {
-      return data._value;
+    // Check for primitive wrapper: {"__roml_value__": ...}
+    if (keys.length === 1 && keys[0] === SYNTHETIC_VALUE_KEY) {
+      return data[SYNTHETIC_VALUE_KEY];
     }
 
     // Regular object - return as-is

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,15 @@ export enum MetaTags {
 }
 
 /**
+ * Synthetic wrapper key names used to encode top-level non-object roots
+ * (arrays, primitives) as if they were objects. These are intentionally
+ * unusual identifiers so they do not collide with realistic user keys; if
+ * a user really has these as root keys, round-trip is lossy by design.
+ */
+export const SYNTHETIC_ITEMS_KEY = '__roml_items__';
+export const SYNTHETIC_VALUE_KEY = '__roml_value__';
+
+/**
  * Document-level features detected during initial scan
  * These features determine META tags and document-wide behavior
  */


### PR DESCRIPTION
## Summary

Top-level non-objects (arrays, primitives) were encoded by wrapping them in synthetic objects with the keys `_items` / `_value`, then unwrapped on decode by matching those exact names. Both are valid JSON keys, so any object root that happened to use them was silently corrupted:

```
{ "_items": [1,2,3] } -> ROML -> [1,2,3]
{ "_value": 42 }      -> ROML -> 42
```

Rename the synthetic wrappers to `__roml_items__` / `__roml_value__` and centralise them in `src/types.ts`. Names stay alphanumeric+underscore so the existing key-quoting rules are unchanged. The collision is now vanishingly unlikely instead of guaranteed.

## BC break

**Yes.** ROML produced before this PR using the old sentinels will not auto-unwrap. Acceptable pre-1.0.

## Failing tests (added in this PR)

```ts
// src/__tests__/WrapperKeyCollision.test.ts
it('round-trips an object whose root key is _items', () => {
  const input = { _items: [1, 2, 3] };
  expect(RomlFile.romlToJson(RomlFile.jsonToRoml(input))).toEqual(input);
});
it('round-trips an object whose root key is _value', () => {
  const input = { _value: 42 };
  expect(RomlFile.romlToJson(RomlFile.jsonToRoml(input))).toEqual(input);
});
// ... plus _value:string, both keys together, true top-level array, true top-level primitive
```

Before fix: 3 of 6 fail (the collisions). After fix: 6 of 6 pass.

## Files touched

- `src/types.ts` — new `SYNTHETIC_ITEMS_KEY` / `SYNTHETIC_VALUE_KEY` constants.
- `src/RomlConverter.ts` — uses constants in wrap, `isSyntheticWrapperKey`, `objectContainsPrimesExcludingWrapperKeys`.
- `src/parser/RomlParser.ts` — `unwrapSyntheticObject` matches the new names.
- `src/lexer/RomlLexer.ts` — single-value pipe-array special case matches the new names.
- `src/__tests__/WrapperKeyCollision.test.ts` — regression coverage.

## Test plan

- [x] `npm install && npm run build && npm run lint && npm test` — 245 tests pass (was 239 + 6 new), lint and build clean.
- [x] CLI round-trip on the colliding case: `echo '{"_items":[1,2,3],"_value":"keep me"}' | node dist/cli.js encode | node dist/cli.js decode` returns the input unchanged.
- [x] CLI round-trip on the synthetic-wrap case: `echo '[1,2,3]' | node dist/cli.js encode | node dist/cli.js decode` returns `[1,2,3]`.

https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV)_