### PR TITLE
fix(encoder): treat leading/trailing quote as ambiguous

### DIFF
--- a/src/RomlConverter.ts
+++ b/src/RomlConverter.ts
@@ -147,6 +147,14 @@ export class RomlConverter {
     // Check if string is whitespace-only (could be confused with missing content)
     if (value.trim() === '') return true;
 
+    // Check if string starts or ends with a quote character. Non-QUOTED
+    // styles emit values verbatim, and the parser unwraps anything matching
+    // /^"(.*)"$/ as a quoted value, which would silently strip the leading
+    // and trailing quote bytes (or mangle the middle for `"a","b"`-style
+    // values). Routing these through QUOTED forces the existing escape
+    // pipeline to handle the embedded quotes correctly.
+    if (value.startsWith('"') || value.endsWith('"')) return true;
+
     // Check if string contains newlines (would break single-line format)
     if (value.includes('\n') || value.includes('\r')) return true;
 

--- a/src/__tests__/EmbeddedQuoteEscaping.test.ts
+++ b/src/__tests__/EmbeddedQuoteEscaping.test.ts
@@ -1,0 +1,48 @@
+import { RomlFile } from '../file/RomlFile';
+
+describe('Embedded-quote escaping in non-QUOTED string styles', () => {
+  // Regression: when a string value happens to start or end with `"`, the
+  // encoder picked a non-QUOTED style (e.g. FAKE_COMMENT, EQUALS, BRACKETS,
+  // DOUBLE_COLON) and emitted the bytes verbatim. The decoder's value-quoting
+  // detection (`/^"(.*)"$/`) then unwrapped what looked like a quoted value,
+  // either dropping the outer quote bytes or mangling the contents:
+  //   {"foo":"\"hello\""}     -> //foo//"hello"     -> {"foo":"hello"}
+  //   {"foo":"\"a\",\"b\""}   -> //foo//"a","b"     -> {"foo":"a\",\"b"}
+  //
+  // Fix: treat any value that starts or ends with `"` as ambiguous so it
+  // routes through the QUOTED style with the existing escape pipeline.
+
+  function roundTrip(input: unknown): unknown {
+    return RomlFile.romlToJson(RomlFile.jsonToRoml(input));
+  }
+
+  it('round-trips a string fully wrapped in literal quotes', () => {
+    const input = { foo: '"hello"' };
+    expect(roundTrip(input)).toEqual(input);
+  });
+
+  it('round-trips a string ending in a literal quote', () => {
+    const input = { foo: 'hello"' };
+    expect(roundTrip(input)).toEqual(input);
+  });
+
+  it('round-trips a string starting with a literal quote', () => {
+    const input = { foo: '"hello' };
+    expect(roundTrip(input)).toEqual(input);
+  });
+
+  it('round-trips a comma-separated quoted-pair string', () => {
+    const input = { foo: '"a","b"' };
+    expect(roundTrip(input)).toEqual(input);
+  });
+
+  it('round-trips a value that is just two quote chars', () => {
+    const input = { foo: '""' };
+    expect(roundTrip(input)).toEqual(input);
+  });
+
+  it('round-trips a string with quotes only in the middle (already worked)', () => {
+    const input = { foo: 'say "hi" please' };
+    expect(roundTrip(input)).toEqual(input);
+  });
+});


### PR DESCRIPTION
## Summary

Strings whose first or last character was a literal `"` round-tripped lossy. The encoder picked a non-QUOTED style (`FAKE_COMMENT`, `EQUALS`, `BRACKETS`, `DOUBLE_COLON`) and emitted the value verbatim; the decoder's value-quoting detection (`/^"(.*)"$/`) then unwrapped what looked like a quoted value:

```
{"foo":"\"hello\""}     -> //foo//"hello"  -> {"foo":"hello"}     // outer quotes lost
{"foo":"\"a\",\"b\""}   -> //foo//"a","b"  -> {"foo":"a\",\"b"}   // bytes mangled
{"foo":"\"\""}          -> //foo//""       -> {"foo":""}          // collapsed to empty
```

Fix: extend `RomlConverter.isAmbiguousString` to flag values that start or end with `"`, routing them through the `QUOTED` style. The existing `escapeStringValue` / `unescapeStringValue` pair already handles embedded quotes correctly (`\"` ↔ `"`), so no new escape logic is needed.

## BC break

No.

## Failing tests (added in this PR)

```ts
// src/__tests__/EmbeddedQuoteEscaping.test.ts
it('round-trips a string fully wrapped in literal quotes', () => {
  expect(roundTrip({ foo: '"hello"' })).toEqual({ foo: '"hello"' });
});
it('round-trips a comma-separated quoted-pair string', () => {
  expect(roundTrip({ foo: '"a","b"' })).toEqual({ foo: '"a","b"' });
});
it('round-trips a value that is just two quote chars', () => {
  expect(roundTrip({ foo: '""' })).toEqual({ foo: '""' });
});
// ... plus leading-only, trailing-only, mid-string (already worked)
```

Before fix: 3 of 6 fail. After fix: 6 of 6 pass.

## Files touched

- `src/RomlConverter.ts` — one new branch in `isAmbiguousString`.
- `src/__tests__/EmbeddedQuoteEscaping.test.ts` — regression coverage.

## Test plan

- [x] `npm install && npm run build && npm run lint && npm test` — 251 tests pass (was 245 + 6 new), lint and build clean.
- [x] CLI smoke test: `printf '%s' '{"foo":"\"hello\"","bar":"\"a\",\"b\""}' | node dist/cli.js encode | node dist/cli.js decode` returns the input bytes intact.

https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV)_