### PR TITLE
fix(encoder): coerce NaN/Infinity/-Infinity to null

### DIFF
--- a/FORMAT.md
+++ b/FORMAT.md
@@ -131,6 +131,9 @@ If no other rules apply, use a deterministic hash-based selection:
 - **whitespace**: Preserved exactly as-is
 - **booleans on odd lines**: `<true>` or `<false>`
 - **booleans on even lines**: `yes` or `no`
+- **NaN, Infinity, -Infinity**: Coerced to `null` on encode, matching
+  `JSON.stringify` behaviour. Round-trip is therefore lossy for non-finite
+  numbers (they become `null`), the same way it is for `JSON.stringify`.
 
 ## Array Encoding Rules
 

--- a/src/RomlConverter.ts
+++ b/src/RomlConverter.ts
@@ -15,6 +15,17 @@ const VOWEL_START = /^[aeiouAEIOU]/;
 const ARRAY_NOTATION = /^\[.*\]$/;
 
 /**
+ * Coerce non-finite numbers (NaN, Infinity, -Infinity) to null. Matches
+ * JSON.stringify, which serialises all three as null. Without this
+ * coercion the encoder would emit the literal identifier (e.g. `NaN`)
+ * and the decoder would round-trip them as the string `"NaN"`.
+ */
+function coerceNonFiniteToNull(value: unknown): unknown {
+  if (typeof value === 'number' && !Number.isFinite(value)) return null;
+  return value;
+}
+
+/**
  * Escape special characters for ROML output
  */
 function escapeForRoml(value: string): string {
@@ -254,6 +265,7 @@ export class RomlConverter {
     value: any,
     context: ConversionContext
   ): { result: string; nextLineNumber: number } {
+    value = coerceNonFiniteToNull(value);
     const indent = '  '.repeat(context.depth);
     const lineFeatures = this.analyzeLineFeatures(key, value, context);
 
@@ -314,6 +326,7 @@ export class RomlConverter {
     array: any[],
     context: ConversionContext
   ): { result: string; nextLineNumber: number } {
+    array = array.map(coerceNonFiniteToNull);
     const indent = '  '.repeat(context.depth);
 
     const hasObjects = array.some(

--- a/src/__tests__/NonFiniteNumbers.test.ts
+++ b/src/__tests__/NonFiniteNumbers.test.ts
@@ -1,0 +1,58 @@
+import { RomlFile } from '../file/RomlFile';
+
+describe('Non-finite number encoding (NaN, Infinity, -Infinity)', () => {
+  // Regression: non-finite numbers were emitted as the literal identifier
+  // (e.g. `&x&NaN`, `&x&Infinity`) and parsed back as the string `"NaN"` /
+  // `"Infinity"`. JSON.stringify coerces all three to `null`, so ROML's
+  // round-trip diverged from the JSON contract.
+  //
+  // Fix: coerce NaN / Infinity / -Infinity to null on encode, matching
+  // JSON.stringify behaviour.
+
+  function jsonStringifyParity(input: unknown): unknown {
+    return JSON.parse(JSON.stringify(input));
+  }
+
+  function roundTrip(input: unknown): unknown {
+    return RomlFile.romlToJson(RomlFile.jsonToRoml(input));
+  }
+
+  it('encodes NaN as null', () => {
+    const input = { x: NaN };
+    expect(roundTrip(input)).toEqual({ x: null });
+    expect(roundTrip(input)).toEqual(jsonStringifyParity(input));
+  });
+
+  it('encodes positive Infinity as null', () => {
+    const input = { x: Infinity };
+    expect(roundTrip(input)).toEqual({ x: null });
+    expect(roundTrip(input)).toEqual(jsonStringifyParity(input));
+  });
+
+  it('encodes negative Infinity as null', () => {
+    const input = { x: -Infinity };
+    expect(roundTrip(input)).toEqual({ x: null });
+    expect(roundTrip(input)).toEqual(jsonStringifyParity(input));
+  });
+
+  it('preserves the literal string "NaN" as a string', () => {
+    // The string "NaN" must NOT be confused with the number NaN.
+    const input = { x: 'NaN' };
+    expect(roundTrip(input)).toEqual(input);
+  });
+
+  it('preserves finite numbers untouched', () => {
+    const input = { a: 0, b: 1, c: -1, d: 1.5, e: -0 };
+    const out = roundTrip(input) as Record<string, number>;
+    expect(out.a).toBe(0);
+    expect(out.b).toBe(1);
+    expect(out.c).toBe(-1);
+    expect(out.d).toBe(1.5);
+  });
+
+  it('coerces non-finite numbers inside arrays', () => {
+    const input = { xs: [1, NaN, 2, Infinity, 3, -Infinity] };
+    expect(roundTrip(input)).toEqual({ xs: [1, null, 2, null, 3, null] });
+    expect(roundTrip(input)).toEqual(jsonStringifyParity(input));
+  });
+});


### PR DESCRIPTION
## Summary

Non-finite numbers were emitted as the literal identifier and round-tripped as strings:

```
{x: NaN}      -> &x&NaN       -> {x: "NaN"}
{x: Infinity} -> &x&Infinity  -> {x: "Infinity"}
```

`JSON.stringify` converts all three to `null`. ROML now matches that contract: `NaN`, `Infinity`, and `-Infinity` are coerced to `null` on encode, both at the scalar level and inside arrays.

Implementation is a single helper `coerceNonFiniteToNull` applied at two narrow sites:

- Top of `convertValue` — covers nested objects, structured-array items, and the wrapper-value path.
- Top of `convertArray` — one shallow `.map` so all four primitive-array inline mappers (PIPES / BRACKETS / JSON_STYLE / COLON_DELIM) see `null` instead of `NaN`.

Documented in `FORMAT.md` under "Special Value Encoding" so the JSON-parity policy is explicit.

## BC break

Effectively no — pre-fix output was already broken (round-tripped as the wrong type). Post-fix output matches `JSON.stringify`.

## Failing tests (added in this PR)

```ts
// src/__tests__/NonFiniteNumbers.test.ts
it('encodes NaN as null',           () => expect(roundTrip({x:NaN})).toEqual({x:null}));
it('encodes positive Infinity as null', ...);
it('encodes negative Infinity as null', ...);
it('preserves the literal string "NaN" as a string', ...);
it('preserves finite numbers untouched', ...);
it('coerces non-finite numbers inside arrays', () => {
  expect(roundTrip({xs:[1,NaN,2,Infinity,3,-Infinity]}))
    .toEqual({xs:[1,null,2,null,3,null]});
});
```

Before fix: 4 of 6 fail. After fix: 6 of 6 pass.

## Files touched

- `src/RomlConverter.ts` — `coerceNonFiniteToNull` helper + 2 call sites.
- `FORMAT.md` — policy entry.
- `src/__tests__/NonFiniteNumbers.test.ts` — regression coverage.

## Test plan

- [x] `npm install && npm run build && npm run lint && npm test` — 257 tests pass (was 251 + 6 new), lint and build clean.
- [x] Smoke test confirms ROML round-trip matches `JSON.parse(JSON.stringify(...))` for all three non-finite values.

https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV)_