### PR TITLE
fix(lexer): reject input without a ~ROML~ header

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,9 @@ jobs:
       - name: Test CLI functionality
         run: |
           echo '{"name":"Robert","age":30,"active":true}' | node dist/cli.js encode
-          echo 'name="Robert"' | node dist/cli.js decode
+          printf '~ROML~\nname="Robert"\n' | node dist/cli.js decode
+          # Round-trip test
+          echo '{"name":"Robert","age":30,"active":true}' | node dist/cli.js encode | node dist/cli.js decode
       
       - name: Test round-trip conversion with examples
         run: |

--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ The same JSON structure always produces identical ROML output. The alternating p
 - **Null values**: `__NULL__`
 - **Empty strings**: `__EMPTY__`
 - **Whitespace**: Preserved exactly as-is
+- **Non-finite numbers** (`NaN`, `Infinity`, `-Infinity`): Coerced to `null` on encode, matching `JSON.stringify` behaviour
+
+### Parser Strictness
+
+- The `~ROML~` header is mandatory. Decoding input that doesn't begin with `~ROML~` (after blank lines) throws a parse error rather than returning `{}`.
+- Top-level non-object roots (arrays, primitives) are wrapped using the synthetic keys `__roml_items__` / `__roml_value__`. These names are not part of the public format and may change; do not depend on them in hand-written ROML.
 
 ### Prime Number Handling
 

--- a/src/__tests__/HeaderValidation.test.ts
+++ b/src/__tests__/HeaderValidation.test.ts
@@ -1,0 +1,41 @@
+import { RomlFile } from '../file/RomlFile';
+
+describe('Required ~ROML~ header', () => {
+  // Regression: FORMAT.md says every document must begin with `~ROML~`, but
+  // the lexer accepted any input. `romlToJson('not roml')` returned `{}`
+  // silently, indistinguishable from a valid empty document. Now it throws.
+
+  it('throws when input has no ~ROML~ header', () => {
+    expect(() => RomlFile.romlToJson('not roml')).toThrow(/~ROML~/);
+  });
+
+  it('throws when input is a single key-value line with no header', () => {
+    expect(() => RomlFile.romlToJson('foo:7')).toThrow(/~ROML~/);
+  });
+
+  it('throws on the empty string (no header at all)', () => {
+    expect(() => RomlFile.romlToJson('')).toThrow(/~ROML~/);
+  });
+
+  it('throws on a whitespace-only document', () => {
+    expect(() => RomlFile.romlToJson('   \n\n')).toThrow(/~ROML~/);
+  });
+
+  it('still parses a valid empty ROML document', () => {
+    expect(RomlFile.romlToJson('~ROML~')).toEqual({});
+  });
+
+  it('still parses a valid header with content', () => {
+    expect(RomlFile.romlToJson('~ROML~\nfoo:7')).toEqual({ foo: 7 });
+  });
+
+  it('reports a clear error message naming the header', () => {
+    let caught: Error | undefined;
+    try {
+      RomlFile.romlToJson('garbage line one');
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught?.message).toMatch(/~ROML~/);
+  });
+});

--- a/src/__tests__/PrimeValidation.test.ts
+++ b/src/__tests__/PrimeValidation.test.ts
@@ -36,7 +36,8 @@ describe('Prime Number META Tag Validation', () => {
 
     it('should fail when primes are present but META tag is missing', () => {
       // Manually create ROML with prime prefixes but no META tag
-      const romlWithoutMeta = `!count="7"
+      const romlWithoutMeta = `~ROML~
+!count="7"
 !value="13"
 nested{
   !prime="17"
@@ -103,7 +104,8 @@ value="8"`;
 
   describe('Error messages', () => {
     it('should provide line numbers in error messages', () => {
-      const romlWithErrors = `!first="4"
+      const romlWithErrors = `~ROML~
+!first="4"
 !second="5"
 !third="6"`;
 
@@ -194,7 +196,8 @@ value="8"`;
 
   describe('Manual ROML editing scenarios', () => {
     it('should provide helpful error when user forgets META tag', () => {
-      const manualRoml = `!myPrime="7"
+      const manualRoml = `~ROML~
+!myPrime="7"
 regular="value"`;
 
       const lexer = new RomlLexer(manualRoml);

--- a/src/lexer/RomlLexer.ts
+++ b/src/lexer/RomlLexer.ts
@@ -68,17 +68,25 @@ export class RomlLexer {
     // require it to begin with `~ROML~`; otherwise the input is not a
     // ROML document. Blank lines before the header are tolerated.
     let headerLineIndex = -1;
+    let headerTrimmed = '';
     for (let i = 0; i < this.lines.length; i++) {
-      if (this.lines[i].trim() !== '') {
+      const trimmed = this.lines[i].trim();
+      if (trimmed !== '') {
         headerLineIndex = i;
+        headerTrimmed = trimmed;
         break;
       }
     }
-    if (headerLineIndex === -1 || !this.lines[headerLineIndex].trim().startsWith('~ROML~')) {
+    if (headerLineIndex === -1 || !headerTrimmed.startsWith('~ROML~')) {
       throw new Error('Missing ~ROML~ header: input is not a ROML document');
     }
 
-    this.addToken('HEADER', this.lines[headerLineIndex].trim(), 0, headerLineIndex);
+    this.addToken(
+      'HEADER',
+      headerTrimmed,
+      this.getLineStartOffset(headerLineIndex),
+      headerLineIndex
+    );
 
     // Process content lines after the header.
     const contentStart = headerLineIndex + 1;

--- a/src/lexer/RomlLexer.ts
+++ b/src/lexer/RomlLexer.ts
@@ -64,13 +64,24 @@ export class RomlLexer {
   public tokenize(): RomlToken[] {
     this.tokens = [];
 
-    // Process header
-    if (this.lines.length > 0 && this.lines[0].trim().startsWith('~ROML~')) {
-      this.addToken('HEADER', this.lines[0].trim(), 0, 0);
+    // The ~ROML~ header is mandatory. Find the first non-blank line and
+    // require it to begin with `~ROML~`; otherwise the input is not a
+    // ROML document. Blank lines before the header are tolerated.
+    let headerLineIndex = -1;
+    for (let i = 0; i < this.lines.length; i++) {
+      if (this.lines[i].trim() !== '') {
+        headerLineIndex = i;
+        break;
+      }
+    }
+    if (headerLineIndex === -1 || !this.lines[headerLineIndex].trim().startsWith('~ROML~')) {
+      throw new Error('Missing ~ROML~ header: input is not a ROML document');
     }
 
-    // Process content lines
-    const contentStart = this.lines[0]?.trim().startsWith('~ROML~') ? 1 : 0;
+    this.addToken('HEADER', this.lines[headerLineIndex].trim(), 0, headerLineIndex);
+
+    // Process content lines after the header.
+    const contentStart = headerLineIndex + 1;
     this.processLines(this.lines.slice(contentStart), contentStart);
 
     this.addToken('EOF', '', this.input.length, this.lines.length);


### PR DESCRIPTION
## Summary

`FORMAT.md` says every document must begin with `~ROML~`, but the lexer silently accepted header-less input as a valid empty document:

```
RomlFile.romlToJson('not roml')   -> {}    (silent)
RomlFile.romlToJson('foo:7')      -> {}    (silent)
RomlFile.romlToJson('')           -> {}    (silent)
```

Scan past leading blank lines and require the first non-empty line to begin with `~ROML~`; otherwise throw a clear parse error that surfaces through `RomlFile.toJSON` and the CLI:

```
Error: Invalid ROML input
Parse errors: Missing ~ROML~ header: input is not a ROML document
```

Three pre-existing prime-validation fixtures were exercising parser logic with hand-rolled, header-less ROML; they get a `~ROML~` line added since they were never about header validation.

The README also gets a new **Parser Strictness** section that retroactively documents the user-visible contracts from this PR and the two preceding PRs (synthetic wrapper-key sentinels, non-finite-number coercion).

## BC break

**Yes.** Decoders that fed ROML-shaped strings without a header now error instead of returning `{}`. Acceptable pre-1.0; existing valid documents are unaffected.

## Failing tests (added in this PR)

```ts
// src/__tests__/HeaderValidation.test.ts
it('throws when input has no ~ROML~ header', () => {
  expect(() => RomlFile.romlToJson('not roml')).toThrow(/~ROML~/);
});
it('throws when input is a single key-value line with no header', () => {
  expect(() => RomlFile.romlToJson('foo:7')).toThrow(/~ROML~/);
});
it('throws on the empty string (no header at all)', () => { ... });
it('throws on a whitespace-only document', () => { ... });
it('still parses a valid empty ROML document', () => {
  expect(RomlFile.romlToJson('~ROML~')).toEqual({});
});
// ... plus header-with-content and explicit error-message check
```

Before fix: 5 of 7 fail. After fix: 7 of 7 pass.

## Files touched

- `src/lexer/RomlLexer.ts` — header scan and explicit throw.
- `src/__tests__/HeaderValidation.test.ts` — regression coverage.
- `src/__tests__/PrimeValidation.test.ts` — fixture cleanup (3 hand-rolled docs gain `~ROML~`).
- `README.md` — new "Parser Strictness" section + non-finite-number bullet under "Special Values".

## Test plan

- [x] `npm install && npm run build && npm run lint && npm test` — 264 tests pass (was 257 + 7 new), lint and build clean.
- [x] CLI smoke: `echo '~ROML~' | node dist/cli.js decode` → `{}` (exit 0). `echo 'not roml' | node dist/cli.js decode` → clear error, exit 1.

https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV)_