### PR TITLE
fix(parser): reject duplicate keys at the same object scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The same JSON structure always produces identical ROML output. The alternating p
 ### Parser Strictness
 
 - The `~ROML~` header is mandatory. Decoding input that doesn't begin with `~ROML~` (after blank lines) throws a parse error rather than returning `{}`.
+- Duplicate keys at the same object scope are rejected. The same key name in different nested objects or different array items is fine; collisions in the same scope (root, the same `key{...}` block, or the same `[N]{...}` array item) throw a parse error naming the offending key and its line number.
 - Top-level non-object roots (arrays, primitives) are wrapped using the synthetic keys `__roml_items__` / `__roml_value__`. These names are not part of the public format and may change; do not depend on them in hand-written ROML.
 
 ### Prime Number Handling

--- a/src/__tests__/DuplicateKeys.test.ts
+++ b/src/__tests__/DuplicateKeys.test.ts
@@ -1,0 +1,59 @@
+import { RomlFile } from '../file/RomlFile';
+
+describe('Duplicate-key rejection', () => {
+  // Regression: at the same object scope, duplicate keys were silently
+  // last-wins. ROML's determinism story is stronger if it refuses the
+  // ambiguous input outright.
+
+  it('throws on duplicate keys at root', () => {
+    expect(() => RomlFile.romlToJson('~ROML~\nfoo:1\nfoo:2')).toThrow(/duplicate/i);
+  });
+
+  it('reports the duplicated key name in the error', () => {
+    expect(() => RomlFile.romlToJson('~ROML~\nbar=hi\nbar=bye')).toThrow(/bar/);
+  });
+
+  it('throws on duplicate keys in a nested object', () => {
+    const doc = ['~ROML~', 'outer{', '  inner=1', '  inner=2', '}'].join('\n');
+    expect(() => RomlFile.romlToJson(doc)).toThrow(/duplicate/i);
+  });
+
+  it('throws on duplicate keys inside an [N]{...} array item', () => {
+    const doc = [
+      '~ROML~',
+      'items[',
+      '  [0]{',
+      '    name="a"',
+      '    name="b"',
+      '  }',
+      ']',
+    ].join('\n');
+    expect(() => RomlFile.romlToJson(doc)).toThrow(/duplicate/i);
+  });
+
+  it('does not flag the same key name appearing in different scopes', () => {
+    const doc = [
+      '~ROML~',
+      'name="root"',
+      'inner{',
+      '  name="nested"',
+      '}',
+    ].join('\n');
+    expect(RomlFile.romlToJson(doc)).toEqual({ name: 'root', inner: { name: 'nested' } });
+  });
+
+  it('does not flag the same key name appearing in different array items', () => {
+    const doc = [
+      '~ROML~',
+      'items[',
+      '  [0]{',
+      '    name="a"',
+      '  }',
+      '  [1]{',
+      '    name="b"',
+      '  }',
+      ']',
+    ].join('\n');
+    expect(RomlFile.romlToJson(doc)).toEqual({ items: [{ name: 'a' }, { name: 'b' }] });
+  });
+});

--- a/src/parser/RomlParser.ts
+++ b/src/parser/RomlParser.ts
@@ -353,15 +353,26 @@ export class RomlParser {
 
   private objectNodeToData(node: RomlObjectNode): Record<string, any> {
     const result: Record<string, any> = {};
+    const seen = new Set<string>();
+    const recordKey = (key: string, lineNumber: number) => {
+      if (seen.has(key)) {
+        this.errors.push(`Duplicate key "${key}" at line ${lineNumber + 1}`);
+      } else {
+        seen.add(key);
+      }
+    };
 
     for (const prop of node.properties) {
+      recordKey(prop.key, prop.lineNumber);
       result[prop.key] = prop.value;
     }
 
     for (const child of node.children) {
       if (child.type === 'object') {
+        recordKey(child.key!, child.lineNumber);
         result[child.key!] = this.objectNodeToData(child);
       } else if (child.type === 'array') {
+        recordKey(child.key, child.lineNumber);
         result[child.key] = this.arrayNodeToData(child);
       }
     }


### PR DESCRIPTION
## Summary

Duplicate keys at the same object scope were silently last-wins:

```
~ROML~
foo:1
foo:2     -> { foo: 2 }   (no error)
```

ROML's "deterministic" contract is stronger if it refuses the ambiguous input. Track seen keys per scope inside `RomlParser.objectNodeToData`; on collision, push a parse error naming the key and its line number. The existing `RomlFile.toJSON` error path then surfaces it to callers and the CLI:

```
$ printf '~ROML~\nfoo:1\nfoo:2\n' | node dist/cli.js decode
Error: Invalid ROML input
Parse errors: Duplicate key "foo" at line 3
exit=1
```

Same key name in different scopes (different nested objects, different `[N]{...}` array items) is unaffected. Detection runs on the post-prefix-stripped key name, so `!foo:7` and `foo:8` in the same scope correctly collide.

## BC break

**Yes.** ROML that previously parsed silently with last-wins semantics now errors. Acceptable pre-1.0; in practice this only triggers on hand-written documents — encoded ROML never produces duplicates because it walks a JSON object whose keys are already unique.

## Failing tests (added in this PR)

```ts
// src/__tests__/DuplicateKeys.test.ts
it('throws on duplicate keys at root', () => {
  expect(() => RomlFile.romlToJson('~ROML~\nfoo:1\nfoo:2')).toThrow(/duplicate/i);
});
it('reports the duplicated key name in the error', () => {
  expect(() => RomlFile.romlToJson('~ROML~\nbar=hi\nbar=bye')).toThrow(/bar/);
});
it('throws on duplicate keys in a nested object', ...);
it('throws on duplicate keys inside an [N]{...} array item', ...);
it('does not flag the same key name appearing in different scopes', ...);
it('does not flag the same key name appearing in different array items', ...);
```

Before fix: 4 of 6 fail. After fix: 6 of 6 pass.

## Files touched

- `src/parser/RomlParser.ts` — `Set<string>` in `objectNodeToData`; pushes a parse error on collision.
- `src/__tests__/DuplicateKeys.test.ts` — regression coverage (4 positive + 2 negative cases).
- `README.md` — new "Parser Strictness" bullet.

## Test plan

- [x] `npm install && npm run build && npm run lint && npm test` — 270 tests pass (was 264 + 6 new), lint and build clean.
- [x] CLI smoke: `printf '~ROML~\nfoo:1\nfoo:2\n' | node dist/cli.js decode` → clear error, exit 1.

https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV)_