### PR TITLE
fix(file): make RomlFile.parse() error path honest

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ The same JSON structure always produces identical ROML output. The alternating p
 - The `~ROML~` header is mandatory. Decoding input that doesn't begin with `~ROML~` (after blank lines) throws a parse error rather than returning `{}`.
 - Duplicate keys at the same object scope are rejected. The same key name in different nested objects or different array items is fine; collisions in the same scope (root, the same `key{...}` block, or the same `[N]{...}` array item) throw a parse error naming the offending key and its line number.
 - Top-level non-object roots (arrays, primitives) are wrapped using the synthetic keys `__roml_items__` / `__roml_value__`. These names are not part of the public format and may change; do not depend on them in hand-written ROML.
+- `RomlFile.parse()` returns `{ data, errors, ... }`. On error, `data` is `null` (not `{}`) so callers who skip the `errors.length === 0` check fail loudly. `RomlFile.toJSON()` throws when `errors` is non-empty, with the original lexer/parser message embedded.
 
 ### Prime Number Handling
 

--- a/src/__tests__/ParseErrorContract.test.ts
+++ b/src/__tests__/ParseErrorContract.test.ts
@@ -1,0 +1,84 @@
+import { RomlFile } from '../file/RomlFile';
+
+describe('Parse error contract on RomlFile', () => {
+  // Regression: RomlFile.parse() catches lexer/parser errors and returns
+  // them via the `errors` field. Historically the error path also returned
+  // a misleading `data: {}` which is indistinguishable from a valid empty
+  // ROML document. These tests lock in the post-fix contract:
+  //
+  //   - parse()    returns errors[] with the original message preserved.
+  //   - parse()    returns data === null on error (not `{}`).
+  //   - toJSON()   throws with the underlying cause embedded.
+  //   - validate() returns the same errors[].
+
+  describe('lexer-level errors (missing ~ROML~ header)', () => {
+    const broken = 'not a roml document';
+
+    it('parse() returns non-empty errors', () => {
+      const file = new RomlFile(broken);
+      const result = file.parse();
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('parse() preserves the lexer error message verbatim', () => {
+      const file = new RomlFile(broken);
+      const result = file.parse();
+      expect(result.errors[0]).toMatch(/Missing ~ROML~ header/);
+    });
+
+    it('parse() returns data === null on error (not the misleading {})', () => {
+      const file = new RomlFile(broken);
+      const result = file.parse();
+      expect(result.data).toBeNull();
+    });
+
+    it('toJSON() throws with the underlying cause embedded', () => {
+      const file = new RomlFile(broken);
+      expect(() => file.toJSON()).toThrow(/Missing ~ROML~ header/);
+    });
+
+    it('validate() returns the same errors[]', () => {
+      const file = new RomlFile(broken);
+      const v = file.validate();
+      expect(v.valid).toBe(false);
+      expect(v.errors[0]).toMatch(/Missing ~ROML~ header/);
+    });
+  });
+
+  describe('parser-level errors (duplicate keys at the same scope)', () => {
+    const broken = '~ROML~\nfoo:1\nfoo:2';
+
+    it('parse() returns non-empty errors', () => {
+      const file = new RomlFile(broken);
+      const result = file.parse();
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('parse() preserves the parser error message verbatim', () => {
+      const file = new RomlFile(broken);
+      const result = file.parse();
+      expect(result.errors.find((e) => /Duplicate key/.test(e))).toBeDefined();
+    });
+
+    it('toJSON() throws with the underlying cause embedded', () => {
+      const file = new RomlFile(broken);
+      expect(() => file.toJSON()).toThrow(/Duplicate key/);
+    });
+  });
+
+  describe('successful parse', () => {
+    it('parse() returns errors=[] and data is the parsed object', () => {
+      const file = new RomlFile('~ROML~\nfoo:7');
+      const result = file.parse();
+      expect(result.errors).toEqual([]);
+      expect(result.data).toEqual({ foo: 7 });
+    });
+
+    it('validate() reports valid=true with no errors', () => {
+      const file = new RomlFile('~ROML~\nfoo:7');
+      const v = file.validate();
+      expect(v.valid).toBe(true);
+      expect(v.errors).toEqual([]);
+    });
+  });
+});

--- a/src/file/RomlFile.ts
+++ b/src/file/RomlFile.ts
@@ -47,39 +47,51 @@ export class RomlFile {
     try {
       // Use lexer → parser → AST pipeline
       const tokens = this.lexer.tokenize();
-      const parseResult = this.parser.parse(tokens);
-      return parseResult;
+      return this.parser.parse(tokens);
     } catch (error) {
-      // Create minimal AST for error case
-      const errorAST = {
-        type: 'document' as const,
+      return this.buildErrorResult(error);
+    }
+  }
+
+  /**
+   * Build a parse result for an unrecoverable lexer/parser error.
+   *
+   * The original error message is preserved verbatim in `errors[0]` so
+   * callers (and `toJSON`) can surface the underlying cause. `data` is
+   * `null` rather than the misleading `{}` so callers who skip the
+   * `errors.length === 0` check fail loudly instead of silently treating
+   * a broken document as a valid empty one. The AST and metadata are
+   * minimal placeholders to satisfy the `RomlParseResult` shape.
+   */
+  private buildErrorResult(error: unknown): RomlParseResult {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    const emptyAST = {
+      type: 'document' as const,
+      startOffset: 0,
+      endOffset: 0,
+      lineNumber: 0,
+      depth: 0,
+      body: {
+        type: 'object' as const,
         startOffset: 0,
         endOffset: 0,
         lineNumber: 0,
         depth: 0,
-        body: {
-          type: 'object' as const,
-          startOffset: 0,
-          endOffset: 0,
-          lineNumber: 0,
-          depth: 0,
-          properties: [],
-          children: [],
-        },
-      };
-
-      return {
-        data: {},
-        metadata: {
-          checksum: 'error',
-          size: 0,
-          created: new Date().toISOString().split('T')[0],
-          source: 'json',
-        },
-        errors: [error instanceof Error ? error.message : 'Unknown error'],
-        ast: errorAST,
-      };
-    }
+        properties: [],
+        children: [],
+      },
+    };
+    return {
+      data: null,
+      metadata: {
+        checksum: 'error',
+        size: 0,
+        created: new Date().toISOString().split('T')[0],
+        source: 'json',
+      },
+      errors: [message],
+      ast: emptyAST,
+    };
   }
 
   public toJSON(): any {


### PR DESCRIPTION
## Summary

`RomlFile.parse()` caught lexer/parser errors and returned `{ data: {}, errors: [msg], ... }`. The misleading `{}` was indistinguishable from a valid empty ROML document, so any caller who skipped `errors.length === 0` would silently misinterpret a broken document.

The original error message was preserved in `errors`, so the contract was right — the data sentinel was the problem.

- Replace `data: {}` with `data: null` on the error path. Callers who skip the errors gate now fail loudly. The declared type stays `any`, so existing destructuring users still compile.
- Extract the 20-line inline catch-block into a small `buildErrorResult` helper so the bogus-but-required AST/metadata stubs live in one place.

Behavior for the success path is unchanged. `RomlFile.toJSON()` already threw on `errors.length > 0` and that's now locked in by tests.

## BC break

Soft yes — callers reading `result.data` on the error path now get `null` instead of `{}`. The documented way to detect an error has always been `errors.length > 0`; anyone using that gate is unaffected. Acceptable pre-1.0.

## Failing tests (added in this PR)

```ts
// src/__tests__/ParseErrorContract.test.ts (10 tests)
describe('lexer-level errors (missing ~ROML~ header)', () => {
  it('parse() returns non-empty errors', ...);
  it('parse() preserves the lexer error message verbatim', ...);
  it('parse() returns data === null on error (not the misleading {})', ...);
  it('toJSON() throws with the underlying cause embedded', ...);
  it('validate() returns the same errors[]', ...);
});
describe('parser-level errors (duplicate keys at the same scope)', () => {
  it('parse() returns non-empty errors', ...);
  it('parse() preserves the parser error message verbatim', ...);
  it('toJSON() throws with the underlying cause embedded', ...);
});
describe('successful parse', () => {
  it('parse() returns errors=[] and data is the parsed object', ...);
  it('validate() reports valid=true with no errors', ...);
});
```

Before fix: 1 test fails (the `data === null` assertion); the rest already passed and lock in the existing-but-undocumented contract. After fix: 10 of 10 pass.

## Files touched

- `src/file/RomlFile.ts` — extract `buildErrorResult`, change error-path `data` from `{}` to `null`.
- `src/__tests__/ParseErrorContract.test.ts` — regression coverage.
- `README.md` — new "Parser Strictness" bullet documenting the contract.

## Test plan

- [x] `npm install && npm run build && npm run lint && npm test` — 280 tests pass (was 270 + 10 new), lint and build clean.
- [x] CLI smoke: `printf 'not roml\n' | node dist/cli.js decode` → clear error, exit 1.

https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV)_