### PR TITLE
fix(format): preserve `!`-prefix keys against the prime marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ The same JSON structure always produces identical ROML output. The alternating p
 
 - The `~ROML~` header is mandatory. Decoding input that doesn't begin with `~ROML~` (after blank lines) throws a parse error rather than returning `{}`.
 - Duplicate keys at the same object scope are rejected. The same key name in different nested objects or different array items is fine; collisions in the same scope (root, the same `key{...}` block, or the same `[N]{...}` array item) throw a parse error naming the offending key and its line number.
+- JSON keys that actually start with `!` (e.g. `{"!warn": 1}`) round-trip cleanly: the encoder quotes them, and the lexer separates the optional prime-marker `!` from the literal key bytes structurally so neither is mistaken for the other.
 - Top-level non-object roots (arrays, primitives) are wrapped using the synthetic keys `__roml_items__` / `__roml_value__`. These names are not part of the public format and may change; do not depend on them in hand-written ROML.
 - `RomlFile.parse()` returns `{ data, errors, ... }`. On error, `data` is `null` (not `{}`) so callers who skip the `errors.length === 0` check fail loudly. `RomlFile.toJSON()` throws when `errors` is non-empty, with the original lexer/parser message embedded.
 

--- a/src/RomlConverter.ts
+++ b/src/RomlConverter.ts
@@ -191,6 +191,12 @@ export class RomlConverter {
     // Check for keys that start with comment-like syntax
     if (key.startsWith('#') || key.startsWith('//')) return true;
 
+    // Quote keys starting with `!` so the parser doesn't mistake the
+    // leading byte for the prime-marker prefix. Without quoting,
+    // `{"!warn": 1}` would round-trip as `{"warn": 1}` because the
+    // parser strips a leading `!` from any key it encounters.
+    if (key.startsWith('!')) return true;
+
     // Check for whitespace that could break parsing
     if (key.includes(' ') || key.includes('\t') || key.includes('\n')) return true;
 

--- a/src/__tests__/BangPrefixKeys.test.ts
+++ b/src/__tests__/BangPrefixKeys.test.ts
@@ -1,0 +1,53 @@
+import { RomlFile } from '../file/RomlFile';
+
+describe('Keys starting with `!` (collision with prime marker)', () => {
+  // Regression: the parser strips a leading `!` from any key as the prime
+  // marker. Keys whose actual JSON name begins with `!` (e.g. `!warn`) were
+  // round-tripped without the leading byte:
+  //   {"!warn": 1}  -> ROML -> {"warn": 1}
+  // The encoder didn't quote them because `needsQuotedKey` ignored `!`.
+  //
+  // Fix: quote keys starting with `!` so the parser sees the real name
+  // inside quotes and the prime-prefix logic doesn't fire.
+
+  function roundTrip(input: unknown): unknown {
+    return RomlFile.romlToJson(RomlFile.jsonToRoml(input));
+  }
+
+  it('round-trips a string key starting with !', () => {
+    const input = { '!warn': 1 };
+    expect(roundTrip(input)).toEqual(input);
+  });
+
+  it('round-trips a string key starting with ! whose value is also prime', () => {
+    // 7 IS prime; without the fix, `!warn` would be ambiguous with the
+    // prime-marker semantics. With the fix, the key is quoted and treated
+    // as a literal name; the prime prefix would still apply to the
+    // *output*, but only on the unquoted form, so the value being prime
+    // doesn't hide the bug.
+    const input = { '!warn': 7 };
+    expect(roundTrip(input)).toEqual(input);
+  });
+
+  it('round-trips a key that is just !', () => {
+    const input = { '!': 'lonely' };
+    expect(roundTrip(input)).toEqual(input);
+  });
+
+  it('round-trips a !alert key with a string value', () => {
+    const input = { '!alert': 'fire' };
+    expect(roundTrip(input)).toEqual(input);
+  });
+
+  it('round-trips a nested object with !-prefixed keys at multiple levels', () => {
+    const input = { outer: { '!warn': 1, '!error': 'oops' } };
+    expect(roundTrip(input)).toEqual(input);
+  });
+
+  it('still preserves prime-prefix semantics for ordinary keys', () => {
+    // Sanity: the fix must not regress prime-prefix behaviour for normal
+    // keys whose values happen to be prime.
+    const input = { count: 7 };
+    expect(roundTrip(input)).toEqual(input);
+  });
+});

--- a/src/lexer/RomlLexer.ts
+++ b/src/lexer/RomlLexer.ts
@@ -1,6 +1,18 @@
 import { SYNTHETIC_ITEMS_KEY, SYNTHETIC_VALUE_KEY } from '../types.js';
 
 /**
+ * Result of `extractKey`: the literal JSON key name plus structural
+ * metadata about how it was written in the source. The parser uses
+ * `hasPrimePrefix` to drive `primesDetected`; `wasQuoted` is currently
+ * informational only.
+ */
+interface ExtractedKey {
+  key: string;
+  wasQuoted: boolean;
+  hasPrimePrefix: boolean;
+}
+
+/**
  * Unescape string from ROML format - convert escape sequences back to actual characters
  */
 function unescapeStringValue(value: string): string {
@@ -51,9 +63,11 @@ export interface RomlToken {
   depth?: number;
   /**
    * True when the key in the source was wrapped in double quotes
-   * (e.g. `"!warn"=1`). The parser uses this to suppress the
-   * leading-`!` prime-prefix strip for keys whose actual JSON name
-   * starts with `!`.
+   * (e.g. `"!warn"=1`). The lexer strips the quotes from `key` itself;
+   * this flag is informational metadata for downstream tooling that
+   * wants to recover the source's quoting choice. The parser does not
+   * use it for prime-prefix disambiguation — `keyHasPrimePrefix` is
+   * already exclusive of the surrounding quotes.
    */
   keyWasQuoted?: boolean;
   /**
@@ -248,48 +262,54 @@ export class RomlLexer {
   private parseKeyValueLine(
     line: string
   ): [string, unknown, string, boolean, boolean] | null {
-    // `wasQuoted` and `hasPrimePrefix` are set as a side effect each time
-    // `extractKey` is called. The most recent values reflect the key
-    // chosen for the branch that returns. The parser uses them to
-    // distinguish a literal `!`-leading JSON key (quoted in source) from
-    // the prime-marker `!` (always outside the optional quotes).
-    let wasQuoted = false;
-    let hasPrimePrefix = false;
-    const extractKey = (keyPart: string): string => {
-      hasPrimePrefix = false;
-      wasQuoted = false;
+    // `extractKey` returns a structured result so each call site can
+    // explicitly thread the quoting / prime-prefix metadata into its
+    // own return tuple. Earlier iterations used closure side effects
+    // ("most recent call wins"), which silently broke if a branch
+    // happened to call extractKey more than once.
+    const extractKey = (keyPart: string): ExtractedKey => {
       let inner = keyPart;
+      let hasPrimePrefix = false;
       if (inner.startsWith('!')) {
         hasPrimePrefix = true;
         inner = inner.substring(1);
       }
       const quotedKeyMatch = inner.match(/^"(.*)"$/);
       if (quotedKeyMatch) {
-        wasQuoted = true;
-        return unescapeStringValue(quotedKeyMatch[1]);
+        return {
+          key: unescapeStringValue(quotedKeyMatch[1]),
+          wasQuoted: true,
+          hasPrimePrefix,
+        };
       }
       // Unquoted: `inner` is the post-prefix key when there was a `!`,
       // or the original `keyPart` otherwise. Either way, the leading
       // prime marker (if any) has already been stripped here.
-      return inner;
+      return { key: inner, wasQuoted: false, hasPrimePrefix };
     };
 
     // Check special cases FIRST before simple separator analysis
     // This prevents complex patterns from being incorrectly split by analyzeLineStructure
     const specialResult = this.parseSpecialCases(line, extractKey);
     if (specialResult) {
-      return [specialResult[0], specialResult[1], specialResult[2], wasQuoted, hasPrimePrefix];
+      return specialResult;
     }
 
     // Analyze line structure to identify style and key/value positions
     const analysis = this.analyzeLineStructure(line);
     if (analysis) {
       const { style, keyPart, valuePart } = analysis;
-      const key = extractKey(keyPart);
+      const extracted = extractKey(keyPart);
 
       // Parse the value based on the style
-      const valueResult = this.parseValueForStyle(key, valuePart, style);
-      return [valueResult[0], valueResult[1], valueResult[2], wasQuoted, hasPrimePrefix];
+      const valueResult = this.parseValueForStyle(extracted.key, valuePart, style);
+      return [
+        valueResult[0],
+        valueResult[1],
+        valueResult[2],
+        extracted.wasQuoted,
+        extracted.hasPrimePrefix,
+      ];
     }
 
     return null;
@@ -462,12 +482,17 @@ export class RomlLexer {
 
   /**
    * Handle special cases that need custom parsing logic
-   * Only complex patterns that can't be handled by simple separator analysis
+   * Only complex patterns that can't be handled by simple separator analysis.
+   *
+   * Each branch destructures the result of `extractKey` locally and threads
+   * the structural metadata (`wasQuoted`, `hasPrimePrefix`) into its return
+   * tuple. Earlier iterations relied on closure side effects in the caller,
+   * which would silently break if a branch ever called extractKey twice.
    */
   private parseSpecialCases(
     line: string,
-    extractKey: (keyPart: string) => string
-  ): [string, unknown, string] | null {
+    extractKey: (keyPart: string) => ExtractedKey
+  ): [string, unknown, string, boolean, boolean] | null {
     // Parse double colon style: ::key::value::
     if (line.startsWith('::') && line.endsWith('::')) {
       const content = line.slice(2, -2);
@@ -476,14 +501,26 @@ export class RomlLexer {
       if (separatorIndex !== -1) {
         const keyPart = content.slice(0, separatorIndex);
         const valuePart = content.slice(separatorIndex + 2); // +2 to skip both colons
-        const key = extractKey(keyPart);
+        const k = extractKey(keyPart);
 
         // Check if value is quoted
         const quotedValueMatch = valuePart.match(/^"(.+)"$/);
         if (quotedValueMatch) {
-          return [key, unescapeStringValue(quotedValueMatch[1]), 'DOUBLE_COLON'];
+          return [
+            k.key,
+            unescapeStringValue(quotedValueMatch[1]),
+            'DOUBLE_COLON',
+            k.wasQuoted,
+            k.hasPrimePrefix,
+          ];
         }
-        return [key, this.parseSpecialValue(valuePart), 'DOUBLE_COLON'];
+        return [
+          k.key,
+          this.parseSpecialValue(valuePart),
+          'DOUBLE_COLON',
+          k.wasQuoted,
+          k.hasPrimePrefix,
+        ];
       }
     }
 
@@ -494,13 +531,25 @@ export class RomlLexer {
       if (separatorPos !== -1 && content.slice(separatorPos).startsWith('//')) {
         const keyPart = content.slice(0, separatorPos);
         const valuePart = content.slice(separatorPos + 2);
-        const key = extractKey(keyPart);
+        const k = extractKey(keyPart);
 
         const quotedValueMatch = valuePart.match(/^"(.*)"$/);
         if (quotedValueMatch) {
-          return [key, unescapeStringValue(quotedValueMatch[1]), 'FAKE_COMMENT'];
+          return [
+            k.key,
+            unescapeStringValue(quotedValueMatch[1]),
+            'FAKE_COMMENT',
+            k.wasQuoted,
+            k.hasPrimePrefix,
+          ];
         }
-        return [key, this.parseSpecialValue(valuePart), 'FAKE_COMMENT'];
+        return [
+          k.key,
+          this.parseSpecialValue(valuePart),
+          'FAKE_COMMENT',
+          k.wasQuoted,
+          k.hasPrimePrefix,
+        ];
       }
     }
 
@@ -511,13 +560,25 @@ export class RomlLexer {
       if (separatorPos !== -1) {
         const keyPart = content.slice(0, separatorPos);
         const valuePart = content.slice(separatorPos + 1);
-        const key = extractKey(keyPart);
+        const k = extractKey(keyPart);
 
         const quotedValueMatch = valuePart.match(/^"(.+)"$/);
         if (quotedValueMatch) {
-          return [key, unescapeStringValue(quotedValueMatch[1]), 'AT_SANDWICH'];
+          return [
+            k.key,
+            unescapeStringValue(quotedValueMatch[1]),
+            'AT_SANDWICH',
+            k.wasQuoted,
+            k.hasPrimePrefix,
+          ];
         }
-        return [key, this.parseSpecialValue(valuePart), 'AT_SANDWICH'];
+        return [
+          k.key,
+          this.parseSpecialValue(valuePart),
+          'AT_SANDWICH',
+          k.wasQuoted,
+          k.hasPrimePrefix,
+        ];
       }
     }
 
@@ -528,20 +589,32 @@ export class RomlLexer {
       if (separatorPos !== -1) {
         const keyPart = content.slice(0, separatorPos);
         const valuePart = content.slice(separatorPos + 1);
-        const key = extractKey(keyPart);
+        const k = extractKey(keyPart);
 
         const quotedValueMatch = valuePart.match(/^"(.+)"$/);
         if (quotedValueMatch) {
-          return [key, unescapeStringValue(quotedValueMatch[1]), 'UNDERSCORE'];
+          return [
+            k.key,
+            unescapeStringValue(quotedValueMatch[1]),
+            'UNDERSCORE',
+            k.wasQuoted,
+            k.hasPrimePrefix,
+          ];
         }
-        return [key, this.parseSpecialValue(valuePart), 'UNDERSCORE'];
+        return [
+          k.key,
+          this.parseSpecialValue(valuePart),
+          'UNDERSCORE',
+          k.wasQuoted,
+          k.hasPrimePrefix,
+        ];
       }
     }
 
     // Parse multiple brackets (arrays): key<item1><item2>
     const multiBracketMatch = line.match(/^(.+?)(<.+>)+$/);
     if (multiBracketMatch && line.includes('><')) {
-      const key = extractKey(multiBracketMatch[1]);
+      const k = extractKey(multiBracketMatch[1]);
       const items = [...line.matchAll(/<([^>]*)>/g)]
         .map((match) => match[1])
         .filter((itemValue) => itemValue !== '') // Filter out empty brackets
@@ -554,23 +627,23 @@ export class RomlLexer {
           }
           return this.parseSpecialValue(itemValue);
         });
-      return [key, items, 'BRACKETS'];
+      return [k.key, items, 'BRACKETS', k.wasQuoted, k.hasPrimePrefix];
     }
 
     // Parse single bracket style: key<value>
     const bracketMatch = line.match(/^(.+?)<(.+)>$/);
     if (bracketMatch) {
-      const key = extractKey(bracketMatch[1]);
+      const k = extractKey(bracketMatch[1]);
       const value = this.parseSpecialValue(bracketMatch[2]);
-      if (value === 'true') return [key, true, 'BRACKETS'];
-      if (value === 'false') return [key, false, 'BRACKETS'];
-      return [key, value, 'BRACKETS'];
+      if (value === 'true') return [k.key, true, 'BRACKETS', k.wasQuoted, k.hasPrimePrefix];
+      if (value === 'false') return [k.key, false, 'BRACKETS', k.wasQuoted, k.hasPrimePrefix];
+      return [k.key, value, 'BRACKETS', k.wasQuoted, k.hasPrimePrefix];
     }
 
     // Parse pipe arrays: key||item1||item2|| (content between pipes can be empty)
     const pipeArrayMatch = line.match(/^(.+?)\|\|(.*)\|\|$/);
     if (pipeArrayMatch) {
-      const key = extractKey(pipeArrayMatch[1]);
+      const k = extractKey(pipeArrayMatch[1]);
       const value = pipeArrayMatch[2];
       if (value.includes('||')) {
         const items = value
@@ -585,11 +658,11 @@ export class RomlLexer {
             }
             return this.parseSpecialValue(item);
           });
-        return [key, items, 'PIPES'];
+        return [k.key, items, 'PIPES', k.wasQuoted, k.hasPrimePrefix];
       } else {
         // Handle empty array case: key||||
         if (value === '') {
-          return [key, [], 'PIPES'];
+          return [k.key, [], 'PIPES', k.wasQuoted, k.hasPrimePrefix];
         }
 
         // Check if single value is quoted
@@ -599,18 +672,18 @@ export class RomlLexer {
           : this.parseSpecialValue(value);
 
         // For wrapper keys, single values should still be arrays
-        if (key === SYNTHETIC_ITEMS_KEY || key === SYNTHETIC_VALUE_KEY) {
-          return [key, [singleValue], 'PIPES'];
+        if (k.key === SYNTHETIC_ITEMS_KEY || k.key === SYNTHETIC_VALUE_KEY) {
+          return [k.key, [singleValue], 'PIPES', k.wasQuoted, k.hasPrimePrefix];
         }
 
-        return [key, singleValue, 'PIPES'];
+        return [k.key, singleValue, 'PIPES', k.wasQuoted, k.hasPrimePrefix];
       }
     }
 
     // Parse JSON-style arrays: key["item1",7,"true",true]
     const jsonArrayMatch = line.match(/^(.+?)\[(.+)\]$/);
     if (jsonArrayMatch && jsonArrayMatch[2].includes(',')) {
-      const key = extractKey(jsonArrayMatch[1]);
+      const k = extractKey(jsonArrayMatch[1]);
       const arrayContent = jsonArrayMatch[2];
 
       // Parse JSON-style array items
@@ -649,13 +722,13 @@ export class RomlLexer {
         items.push(this.parseJsonValue(trimmed));
       }
 
-      return [key, items, 'JSON_STYLE'];
+      return [k.key, items, 'JSON_STYLE', k.wasQuoted, k.hasPrimePrefix];
     }
 
     // Parse colon-delimited arrays: key:item1:item2:item3
     const colonArrayMatch = line.match(/^(.+?):(.+)$/);
     if (colonArrayMatch && colonArrayMatch[2].includes(':')) {
-      const key = extractKey(colonArrayMatch[1]);
+      const k = extractKey(colonArrayMatch[1]);
       const items = colonArrayMatch[2].split(':').map((item) => {
         // Check if item is quoted (can be empty)
         const quotedMatch = item.match(/^"(.*)"$/);
@@ -665,7 +738,7 @@ export class RomlLexer {
         }
         return this.parseSpecialValue(item);
       });
-      return [key, items, 'COLON_DELIM'];
+      return [k.key, items, 'COLON_DELIM', k.wasQuoted, k.hasPrimePrefix];
     }
 
     return null;

--- a/src/lexer/RomlLexer.ts
+++ b/src/lexer/RomlLexer.ts
@@ -49,6 +49,20 @@ export interface RomlToken {
   key?: string;
   parsedValue?: unknown;
   depth?: number;
+  /**
+   * True when the key in the source was wrapped in double quotes
+   * (e.g. `"!warn"=1`). The parser uses this to suppress the
+   * leading-`!` prime-prefix strip for keys whose actual JSON name
+   * starts with `!`.
+   */
+  keyWasQuoted?: boolean;
+  /**
+   * True when the source line carried a prime-marker `!` immediately
+   * before the (possibly-quoted) key, e.g. `!count:7` or `!"!warn":7`.
+   * The lexer strips the `!` so `key` is always the post-prefix name;
+   * the parser uses this flag to mark `primesDetected` and validate.
+   */
+  keyHasPrimePrefix?: boolean;
 }
 
 export class RomlLexer {
@@ -212,30 +226,59 @@ export class RomlLexer {
       const contentLine = line.trimStart();
       const parsed = this.parseKeyValueLine(contentLine);
       if (parsed) {
-        const [key, value, style] = parsed;
-        this.addToken('KEY_VALUE', contentLine, startOffset, lineNumber, style, key, value, depth);
+        const [key, value, style, keyWasQuoted, keyHasPrimePrefix] = parsed;
+        this.addToken(
+          'KEY_VALUE',
+          contentLine,
+          startOffset,
+          lineNumber,
+          style,
+          key,
+          value,
+          depth,
+          keyWasQuoted,
+          keyHasPrimePrefix
+        );
       }
 
       i++;
     }
   }
 
-  private parseKeyValueLine(line: string): [string, unknown, string] | null {
-    // Helper function to extract and unescape quoted keys
+  private parseKeyValueLine(
+    line: string
+  ): [string, unknown, string, boolean, boolean] | null {
+    // `wasQuoted` and `hasPrimePrefix` are set as a side effect each time
+    // `extractKey` is called. The most recent values reflect the key
+    // chosen for the branch that returns. The parser uses them to
+    // distinguish a literal `!`-leading JSON key (quoted in source) from
+    // the prime-marker `!` (always outside the optional quotes).
+    let wasQuoted = false;
+    let hasPrimePrefix = false;
     const extractKey = (keyPart: string): string => {
-      const quotedKeyMatch = keyPart.match(/^"(.*)"$/);
+      hasPrimePrefix = false;
+      wasQuoted = false;
+      let inner = keyPart;
+      if (inner.startsWith('!')) {
+        hasPrimePrefix = true;
+        inner = inner.substring(1);
+      }
+      const quotedKeyMatch = inner.match(/^"(.*)"$/);
       if (quotedKeyMatch) {
-        // Unescape all special characters in key names (same as unescapeStringValue)
+        wasQuoted = true;
         return unescapeStringValue(quotedKeyMatch[1]);
       }
-      return keyPart;
+      // Unquoted: `inner` is the post-prefix key when there was a `!`,
+      // or the original `keyPart` otherwise. Either way, the leading
+      // prime marker (if any) has already been stripped here.
+      return inner;
     };
 
     // Check special cases FIRST before simple separator analysis
     // This prevents complex patterns from being incorrectly split by analyzeLineStructure
     const specialResult = this.parseSpecialCases(line, extractKey);
     if (specialResult) {
-      return specialResult;
+      return [specialResult[0], specialResult[1], specialResult[2], wasQuoted, hasPrimePrefix];
     }
 
     // Analyze line structure to identify style and key/value positions
@@ -245,7 +288,8 @@ export class RomlLexer {
       const key = extractKey(keyPart);
 
       // Parse the value based on the style
-      return this.parseValueForStyle(key, valuePart, style);
+      const valueResult = this.parseValueForStyle(key, valuePart, style);
+      return [valueResult[0], valueResult[1], valueResult[2], wasQuoted, hasPrimePrefix];
     }
 
     return null;
@@ -526,7 +570,7 @@ export class RomlLexer {
     // Parse pipe arrays: key||item1||item2|| (content between pipes can be empty)
     const pipeArrayMatch = line.match(/^(.+?)\|\|(.*)\|\|$/);
     if (pipeArrayMatch) {
-      const key = pipeArrayMatch[1];
+      const key = extractKey(pipeArrayMatch[1]);
       const value = pipeArrayMatch[2];
       if (value.includes('||')) {
         const items = value
@@ -566,7 +610,7 @@ export class RomlLexer {
     // Parse JSON-style arrays: key["item1",7,"true",true]
     const jsonArrayMatch = line.match(/^(.+?)\[(.+)\]$/);
     if (jsonArrayMatch && jsonArrayMatch[2].includes(',')) {
-      const key = jsonArrayMatch[1];
+      const key = extractKey(jsonArrayMatch[1]);
       const arrayContent = jsonArrayMatch[2];
 
       // Parse JSON-style array items
@@ -611,7 +655,7 @@ export class RomlLexer {
     // Parse colon-delimited arrays: key:item1:item2:item3
     const colonArrayMatch = line.match(/^(.+?):(.+)$/);
     if (colonArrayMatch && colonArrayMatch[2].includes(':')) {
-      const key = colonArrayMatch[1];
+      const key = extractKey(colonArrayMatch[1]);
       const items = colonArrayMatch[2].split(':').map((item) => {
         // Check if item is quoted (can be empty)
         const quotedMatch = item.match(/^"(.*)"$/);
@@ -696,7 +740,9 @@ export class RomlLexer {
     style?: string,
     key?: string,
     parsedValue?: unknown,
-    depth?: number
+    depth?: number,
+    keyWasQuoted?: boolean,
+    keyHasPrimePrefix?: boolean
   ): void {
     this.tokens.push({
       type,
@@ -708,6 +754,8 @@ export class RomlLexer {
       key,
       parsedValue,
       depth,
+      keyWasQuoted,
+      keyHasPrimePrefix,
     });
   }
 }

--- a/src/parser/RomlParser.ts
+++ b/src/parser/RomlParser.ts
@@ -301,11 +301,16 @@ export class RomlParser {
       }
 
       if (numericValue !== null && !this.isPrime(numericValue)) {
+        // `cleanKey` is unescaped, so it can contain `"`, `\n`, control
+        // chars, etc. Use JSON.stringify to render an unambiguous,
+        // self-delimiting representation of the key including the `!`
+        // prime marker.
+        const displayKey = JSON.stringify('!' + cleanKey);
         this.invalidPrimeKeys.push(
-          `Line ${token.lineNumber + 1}: Key "!${cleanKey}" has prime prefix but value ${numericValue} is not prime`
+          `Line ${token.lineNumber + 1}: Key ${displayKey} has prime prefix but value ${numericValue} is not prime`
         );
         this.errors.push(
-          `Invalid prime prefix at line ${token.lineNumber + 1}: Key "!${cleanKey}" is marked as prime but value ${numericValue} is not a prime number`
+          `Invalid prime prefix at line ${token.lineNumber + 1}: Key ${displayKey} is marked as prime but value ${numericValue} is not a prime number`
         );
       }
     }

--- a/src/parser/RomlParser.ts
+++ b/src/parser/RomlParser.ts
@@ -280,11 +280,14 @@ export class RomlParser {
   private parseKeyValue(token: RomlToken): RomlKeyValueNode | null {
     if (token.key === undefined || token.parsedValue === undefined) return null;
 
-    // Check for prime prefixes and validate
-    let cleanKey = token.key;
-    if (token.key.startsWith('!')) {
+    // The lexer already strips any prime-marker `!` and surrounding
+    // quotes from `token.key`, surfacing the structural information via
+    // `token.keyHasPrimePrefix` and `token.keyWasQuoted`. So `token.key`
+    // is the literal JSON key name; we just decide whether to treat the
+    // line as a prime-prefixed line.
+    const cleanKey = token.key;
+    if (token.keyHasPrimePrefix) {
       this.primesDetected = true;
-      cleanKey = token.key.substring(1);
 
       // Validate that the value is actually prime (handle both numbers and numeric strings)
       let numericValue: number | null = null;
@@ -299,10 +302,10 @@ export class RomlParser {
 
       if (numericValue !== null && !this.isPrime(numericValue)) {
         this.invalidPrimeKeys.push(
-          `Line ${token.lineNumber + 1}: Key "${token.key}" has prime prefix but value ${numericValue} is not prime`
+          `Line ${token.lineNumber + 1}: Key "!${cleanKey}" has prime prefix but value ${numericValue} is not prime`
         );
         this.errors.push(
-          `Invalid prime prefix at line ${token.lineNumber + 1}: Key "${token.key}" is marked as prime but value ${numericValue} is not a prime number`
+          `Invalid prime prefix at line ${token.lineNumber + 1}: Key "!${cleanKey}" is marked as prime but value ${numericValue} is not a prime number`
         );
       }
     }


### PR DESCRIPTION
## Summary

JSON keys whose name actually starts with `!` (e.g. `{"!warn": 1}`) lost the leading byte on round-trip because the parser unconditionally stripped a leading `!` from any key as the prime marker:

```
{"!warn": 1}        -> ROML -> {"warn": 1}
{"!alert": "fire"}  -> ROML -> {"alert": "fire"}
```

Three coordinated changes fix this:

**1. Encoder** (`RomlConverter.needsQuotedKey`) — quote keys starting with `!` so the parser sees them wrapped in `"..."`.

**2. Lexer** — separate the prime-marker `!` from the literal key bytes structurally inside `extractKey`. The lexer now strips an optional leading `!` *and* surrounding quotes before producing `token.key`, surfacing the structural information via two new optional token fields:

- `keyWasQuoted` — the source key was wrapped in `"..."`.
- `keyHasPrimePrefix` — the source line carried a `!` prime marker.

The three array-regex branches in `parseSpecialCases` (pipe, JSON-style, colon-delim) also route their key through `extractKey` now, matching the already-`extractKey`-aware multi-bracket and scalar paths so prime-prefix detection is uniform across array styles.

**3. Parser** (`parseKeyValue`) — drive `primesDetected` and prime-validation off `token.keyHasPrimePrefix` instead of inspecting `token.key` for a leading `!` (which is now always already stripped). The displayed key in the prime-validation error message reattaches `!` so messages stay readable (`Key "!warn"`).

This also fixes the prime-prefix detection on array-valued keys generally — `{"foo": [1,2]}` now consistently goes through `extractKey` regardless of which array style the encoder picks.

## BC break

No external API change. Token interface gains two optional fields; existing token consumers are unaffected.

## Failing tests (added in this PR)

```ts
// src/__tests__/BangPrefixKeys.test.ts (6 tests)
it('round-trips a string key starting with !', () => {
  expect(roundTrip({ '!warn': 1 })).toEqual({ '!warn': 1 });
});
it('round-trips a string key starting with ! whose value is also prime', () => {
  expect(roundTrip({ '!warn': 7 })).toEqual({ '!warn': 7 });
});
it('round-trips a key that is just !', ...);
it('round-trips a !alert key with a string value', ...);
it('round-trips a nested object with !-prefixed keys at multiple levels', ...);
it('still preserves prime-prefix semantics for ordinary keys', ...);
```

Before fix: 5 of 6 fail. After fix: 6 of 6 pass.

## Files touched

- `src/RomlConverter.ts` — one new branch in `needsQuotedKey`.
- `src/lexer/RomlLexer.ts` — `keyWasQuoted` / `keyHasPrimePrefix` token fields, structural prime-prefix strip in `extractKey`, three array branches now use `extractKey`.
- `src/parser/RomlParser.ts` — `parseKeyValue` reads from token flags instead of inspecting `token.key`.
- `src/__tests__/BangPrefixKeys.test.ts` — regression coverage.
- `README.md` — new "Parser Strictness" bullet.

## Test plan

- [x] `npm install && npm run build && npm run lint && npm test` — 286 tests pass (was 280 + 6 new), lint and build clean.
- [x] CLI smoke: `echo '{"!warn":1,"!alert":"oops","!prime":7,"normal":13}' | node dist/cli.js encode | node dist/cli.js decode` returns the input unchanged.

https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV)_