### PR TITLE
fix(encoder): treat strings ending in `{` or `[` as ambiguous

### DIFF
--- a/src/RomlConverter.ts
+++ b/src/RomlConverter.ts
@@ -171,6 +171,15 @@ export class RomlConverter {
     // pipeline to handle the embedded quotes correctly.
     if (value.startsWith('"') || value.endsWith('"')) return true;
 
+    // Check if string ends with `{` or `[`. The lexer interprets any
+    // line ending in `{` as OBJECT_START and any line ending in `[`
+    // as ARRAY_START regardless of what came before, so a string
+    // value like `"{"` would emit (e.g.) `//key//{` and silently be
+    // reinterpreted as opening a child object. Routing through
+    // QUOTED produces `key="{"` which the lexer parses as a regular
+    // key/value.
+    if (value.endsWith('{') || value.endsWith('[')) return true;
+
     // Check if string contains newlines (would break single-line format)
     if (value.includes('\n') || value.includes('\r')) return true;
 

--- a/src/RomlConverter.ts
+++ b/src/RomlConverter.ts
@@ -171,14 +171,15 @@ export class RomlConverter {
     // pipeline to handle the embedded quotes correctly.
     if (value.startsWith('"') || value.endsWith('"')) return true;
 
-    // Check if string ends with `{` or `[`. The lexer interprets any
-    // line ending in `{` as OBJECT_START and any line ending in `[`
-    // as ARRAY_START regardless of what came before, so a string
-    // value like `"{"` would emit (e.g.) `//key//{` and silently be
-    // reinterpreted as opening a child object. Routing through
-    // QUOTED produces `key="{"` which the lexer parses as a regular
-    // key/value.
-    if (value.endsWith('{') || value.endsWith('[')) return true;
+    // Check if string ends with `{` or `[` (after trimming trailing
+    // whitespace). The lexer trims every line before matching the
+    // OBJECT_START / ARRAY_START regexes, so a value like `'open { '`
+    // would still be mis-tokenized as `OBJECT_START` after lexer
+    // trimming even though the raw value doesn't end with `{`. Use
+    // `trimEnd()` so values with trailing whitespace before the
+    // structural char are also routed through `QUOTED`.
+    const trimmedEnd = value.trimEnd();
+    if (trimmedEnd.endsWith('{') || trimmedEnd.endsWith('[')) return true;
 
     // Check if string contains newlines (would break single-line format)
     if (value.includes('\n') || value.includes('\r')) return true;

--- a/src/__tests__/StringsEndingInBraceOrBracket.test.ts
+++ b/src/__tests__/StringsEndingInBraceOrBracket.test.ts
@@ -1,0 +1,51 @@
+import { RomlFile } from '../file/RomlFile';
+
+describe('Strings ending in `{` or `[` (collision with OBJECT_START / ARRAY_START)', () => {
+  // Regression: the lexer interprets any line ending in `{` as an
+  // OBJECT_START and any line ending in `[` as an ARRAY_START
+  // regardless of the line's structure. A string value `"{"` would
+  // emit `//key//{` (FAKE_COMMENT) and silently be reinterpreted as
+  // opening a child object whose key is `//key//`. Same shape for `[`.
+  //
+  // Fix: route values ending in `{` or `[` through the QUOTED style,
+  // where the trailing brace/bracket is inside `"…"` and can no
+  // longer be mistaken for a structural opener.
+
+  function roundTrip(input: unknown): unknown {
+    return RomlFile.romlToJson(RomlFile.jsonToRoml(input));
+  }
+
+  it('round-trips a value that is just `{`', () => {
+    expect(roundTrip({ k: '{' })).toEqual({ k: '{' });
+  });
+
+  it('round-trips a value that is just `[`', () => {
+    expect(roundTrip({ k: '[' })).toEqual({ k: '[' });
+  });
+
+  it('round-trips a value ending in `{`', () => {
+    expect(roundTrip({ k: 'open {' })).toEqual({ k: 'open {' });
+  });
+
+  it('round-trips a value ending in `[`', () => {
+    expect(roundTrip({ k: 'list [' })).toEqual({ k: 'list [' });
+  });
+
+  it('round-trips top-level string `{`', () => {
+    expect(roundTrip('{')).toEqual('{');
+  });
+
+  it('round-trips top-level string `[`', () => {
+    expect(roundTrip('[')).toEqual('[');
+  });
+
+  it('round-trips an array element that is just `{`', () => {
+    expect(roundTrip({ xs: ['{', '[', 'plain'] })).toEqual({
+      xs: ['{', '[', 'plain'],
+    });
+  });
+
+  it('still preserves a string that has `{` in the middle (sanity)', () => {
+    expect(roundTrip({ k: 'mid{dle' })).toEqual({ k: 'mid{dle' });
+  });
+});

--- a/src/__tests__/StringsEndingInBraceOrBracket.test.ts
+++ b/src/__tests__/StringsEndingInBraceOrBracket.test.ts
@@ -48,4 +48,20 @@ describe('Strings ending in `{` or `[` (collision with OBJECT_START / ARRAY_STAR
   it('still preserves a string that has `{` in the middle (sanity)', () => {
     expect(roundTrip({ k: 'mid{dle' })).toEqual({ k: 'mid{dle' });
   });
+
+  // The lexer trims every line before matching its OBJECT_START /
+  // ARRAY_START patterns, so trailing whitespace doesn't save a value
+  // from being mis-tokenized. The encoder must use `trimEnd()` when
+  // checking for the structural-opener tail.
+  it('round-trips a value ending in `{ ` (trailing space)', () => {
+    expect(roundTrip({ k: 'open { ' })).toEqual({ k: 'open { ' });
+  });
+
+  it('round-trips a value ending in `[\\t` (trailing tab)', () => {
+    expect(roundTrip({ k: 'list [\t' })).toEqual({ k: 'list [\t' });
+  });
+
+  it('round-trips a value that is just `{   `', () => {
+    expect(roundTrip({ k: '{   ' })).toEqual({ k: '{   ' });
+  });
 });


### PR DESCRIPTION
## Summary

The lexer interprets any line ending in `{` as `OBJECT_START` and any line ending in `[` as `ARRAY_START`, regardless of what came before on the line. A string value `"{"` (or any value ending in `{` / `[`) would emit something like `//key//{` and silently be reinterpreted as opening a child object whose key was `//key//`:

```
{"k":"{"}  -> //k//{                  -> {"//k//": {}}
"["        -> __roml_value__//[       -> {"__roml_value__": []}
```

Same shape and same family as the surrounding-quotes fix in #12 (PR 3). Surfaced while exploring property-based round-trip coverage; reduced to a hand-written regression test for this PR per the small-PR convention.

Extend `RomlConverter.isAmbiguousString` to flag values ending in `{` or `[`, routing them through `QUOTED` where the trailing brace/bracket is inside `"…"` and can no longer be mistaken for a structural opener.

## BC break

No.

## Failing tests (added in this PR)

```ts
// src/__tests__/StringsEndingInBraceOrBracket.test.ts (8 tests)
it('round-trips a value that is just `{`',  () => expect(rt({k:'{'})).toEqual({k:'{'}));
it('round-trips a value that is just `[`',  ...);
it('round-trips a value ending in `{`',     ...);
it('round-trips a value ending in `[`',     ...);
it('round-trips top-level string `{`',      () => expect(rt('{')).toEqual('{'));
it('round-trips top-level string `[`',      ...);
it('round-trips an array element that is just `{`', ...);
it('still preserves a string that has `{` in the middle (sanity)', ...);
```

Before fix: 6 of 8 fail. After fix: 8 of 8 pass.

## Files touched

- `src/RomlConverter.ts` — one new branch in `isAmbiguousString`.
- `src/__tests__/StringsEndingInBraceOrBracket.test.ts` — regression coverage.

## Test plan

- [x] `npm install && npm run build && npm run lint && npm test` — 314 tests pass (was 306 + 8 new), lint and build clean.
- [x] Smoke: `node -e 'const {RomlFile}=require("./dist/file/RomlFile.js"); console.log(JSON.stringify(RomlFile.romlToJson(RomlFile.jsonToRoml({k:"{"}))));'` returns `{"k":"{"}` rather than `{"//k//":{}}`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV)_