### PR TITLE
fix(format): quote/unquote keys consistently across all token shapes

### DIFF
--- a/src/RomlConverter.ts
+++ b/src/RomlConverter.ts
@@ -368,6 +368,11 @@ export class RomlConverter {
       // Analyze if this array contains primes
       const lineFeatures = this.analyzeLineFeatures(key, array, context);
       const prefix = lineFeatures.containsPrime ? '!' : '';
+      // Quote the key if needed so the lexer can recover it cleanly.
+      // Without this, e.g. an empty-string key with an array value
+      // emits a bare `[` which the lexer's `arrayMatch` regex
+      // (`^(.+?)\[$`) cannot capture, and the line is silently dropped.
+      const formattedKey = formatKeyName(key, lineFeatures.needsQuotedKey);
 
       const newContext: ConversionContext = {
         ...context,
@@ -381,9 +386,26 @@ export class RomlConverter {
         const itemContext = { ...newContext, lineNumber: currentLineNumber };
 
         if (typeof item === 'object' && item !== null && !Array.isArray(item)) {
-          const converted = this.convertObject(`[${index}]`, item, itemContext);
-          arrayItems.push(converted.result);
-          currentLineNumber = converted.nextLineNumber;
+          // Emit the structural `[index]{...}` opener directly rather
+          // than routing the `[N]` key through `convertObject`'s
+          // with-key branch. That branch (correctly) calls
+          // `formatKeyName`, which would quote `[0]` because
+          // `needsQuotedKey` flags any `[...]`-shaped key — but the
+          // lexer's `arrayItemMatch` regex only matches the unquoted
+          // form. The user's own `{"[0]": x}` keys still go through
+          // `convertObject` with-key and get quoted; only the
+          // structural use here bypasses formatting.
+          const itemIndent = '  '.repeat(itemContext.depth);
+          const bodyContext: ConversionContext = {
+            ...itemContext,
+            depth: itemContext.depth + 1,
+            lineNumber: currentLineNumber + 1,
+          };
+          const body = this.convertObject(item, bodyContext);
+          arrayItems.push(
+            `${itemIndent}[${index}]{\n${body.result}\n${itemIndent}}`
+          );
+          currentLineNumber = body.nextLineNumber + 1;
         } else {
           const converted = this.convertValue(`[${index}]`, item, itemContext);
           arrayItems.push(converted.result);
@@ -392,7 +414,7 @@ export class RomlConverter {
       }
 
       return {
-        result: `${indent}${prefix}${key}[\n${arrayItems.join('\n')}\n${indent}]`,
+        result: `${indent}${prefix}${formattedKey}[\n${arrayItems.join('\n')}\n${indent}]`,
         nextLineNumber: currentLineNumber + 1,
       };
     }
@@ -401,6 +423,11 @@ export class RomlConverter {
     const arrayStyle = this.selectArrayStyle(key, context);
     const lineFeatures = this.analyzeLineFeatures(key, array, context);
     const prefix = lineFeatures.containsPrime ? '!' : '';
+    // Quote the key if needed so the lexer can recover it cleanly.
+    // Without this, e.g. an empty-string key with an empty array
+    // would emit `||||` (no key bytes at all) which the lexer's
+    // pipe-array regex can't capture.
+    const formattedKey = formatKeyName(key, lineFeatures.needsQuotedKey);
 
     switch (arrayStyle) {
       case 'PIPES':
@@ -417,7 +444,7 @@ export class RomlConverter {
           })
           .join('||');
         return {
-          result: `${indent}${prefix}${key}||${pipeItems}||`,
+          result: `${indent}${prefix}${formattedKey}||${pipeItems}||`,
           nextLineNumber: context.lineNumber + 1,
         };
 
@@ -439,7 +466,7 @@ export class RomlConverter {
         const finalBracketItems = array.length === 1 ? `${bracketItems}<>` : bracketItems;
 
         return {
-          result: `${indent}${prefix}${key}${finalBracketItems}`,
+          result: `${indent}${prefix}${formattedKey}${finalBracketItems}`,
           nextLineNumber: context.lineNumber + 1,
         };
 
@@ -456,7 +483,7 @@ export class RomlConverter {
           return String(item);
         });
         return {
-          result: `${indent}${prefix}${key}[${jsonItems.join(',')}]`,
+          result: `${indent}${prefix}${formattedKey}[${jsonItems.join(',')}]`,
           nextLineNumber: context.lineNumber + 1,
         };
 
@@ -472,13 +499,13 @@ export class RomlConverter {
           return String(item);
         });
         return {
-          result: `${indent}${prefix}${key}:${colonItems.join(':')}`,
+          result: `${indent}${prefix}${formattedKey}:${colonItems.join(':')}`,
           nextLineNumber: context.lineNumber + 1,
         };
 
       default:
         return {
-          result: `${indent}${prefix}${key}||${array.join('||')}||`,
+          result: `${indent}${prefix}${formattedKey}||${array.join('||')}||`,
           nextLineNumber: context.lineNumber + 1,
         };
     }
@@ -498,6 +525,11 @@ export class RomlConverter {
       // For objects, don't add prefix to the object key itself
       // The prefix will be added to individual keys with prime values inside
       const prefix = '';
+      // Quote the key if needed so the lexer can recover it cleanly.
+      // Without this, an empty-string key emits a bare `{` which the
+      // lexer's `objectMatch` regex (`^(.+?)\{$`) cannot capture, and
+      // the line is silently dropped.
+      const formattedKey = formatKeyName(key, this.needsQuotedKey(key));
 
       const newContext: ConversionContext = {
         ...context,
@@ -515,7 +547,7 @@ export class RomlConverter {
       }
 
       return {
-        result: `${indent}${prefix}${key}{\n${entries.join('\n')}\n${indent}}`,
+        result: `${indent}${prefix}${formattedKey}{\n${entries.join('\n')}\n${indent}}`,
         nextLineNumber: currentLineNumber + 1,
       };
     } else {

--- a/src/__tests__/ObjectArrayStartKey.test.ts
+++ b/src/__tests__/ObjectArrayStartKey.test.ts
@@ -1,0 +1,74 @@
+import { RomlFile } from '../file/RomlFile';
+
+describe('OBJECT_START / ARRAY_START key quoting symmetry', () => {
+  // Regression: KEY_VALUE lines route the key through `formatKeyName`
+  // (which quotes empty / whitespace / separator-char keys), but the
+  // encoder's OBJECT_START (`key{`) and ARRAY_START (`key[`) emitters
+  // used the raw key. An empty-string key with an object value then
+  // emits a bare `{` on a line, which the lexer matches against `^}$`
+  // / `^]$` / `^(.+?)\{$` / etc — a leading `{` requires at least one
+  // char before it, so the line is silently dropped. Same shape for
+  // arrays. Whitespace-only / separator-char keys with object or array
+  // values had analogous failures.
+  //
+  // Fix: format the key in the encoder for OBJECT_START / ARRAY_START
+  // emit, then teach the lexer to extract the same way as KEY_VALUE
+  // (strip optional `!` and surrounding `"…"`) and the parser to
+  // consume the cleaned key directly.
+
+  function roundTrip(input: unknown): unknown {
+    return RomlFile.romlToJson(RomlFile.jsonToRoml(input));
+  }
+
+  it('round-trips an empty-string key whose value is an object', () => {
+    expect(roundTrip({ '': {} })).toEqual({ '': {} });
+  });
+
+  it('round-trips an empty-string key whose value is an array', () => {
+    expect(roundTrip({ '': [] })).toEqual({ '': [] });
+  });
+
+  it('round-trips a space-only key whose value is an object', () => {
+    expect(roundTrip({ ' ': {} })).toEqual({ ' ': {} });
+  });
+
+  it('round-trips a key containing `=` whose value is an object', () => {
+    expect(roundTrip({ 'a=b': { x: 1 } })).toEqual({ 'a=b': { x: 1 } });
+  });
+
+  it('round-trips a key containing `<` whose value is an object', () => {
+    expect(roundTrip({ '<key>': { x: 1 } })).toEqual({ '<key>': { x: 1 } });
+  });
+
+  it('round-trips a key containing `:` whose value is an array of objects', () => {
+    expect(roundTrip({ 'a:b': [{ x: 1 }, { y: 2 }] })).toEqual({
+      'a:b': [{ x: 1 }, { y: 2 }],
+    });
+  });
+
+  it('round-trips a quoted-key user-supplied `[0]` shape (still allowed as a regular key)', () => {
+    // The structural `[N]` form is reserved for array items, but a
+    // user object can still legitimately use `[0]` as a key with an
+    // object value — the encoder must quote it, and the lexer must
+    // distinguish it from an array-item opener.
+    expect(roundTrip({ '[0]': { x: 1 } })).toEqual({ '[0]': { x: 1 } });
+  });
+
+  it('still round-trips a normal nested object (sanity)', () => {
+    expect(roundTrip({ outer: { inner: 1 } })).toEqual({ outer: { inner: 1 } });
+  });
+
+  it('still round-trips a normal nested array (sanity)', () => {
+    expect(roundTrip({ items: [{ a: 1 }, { b: 2 }] })).toEqual({
+      items: [{ a: 1 }, { b: 2 }],
+    });
+  });
+
+  it('still preserves the prime prefix on an object-valued key whose key was quoted', () => {
+    // `[0]` triggers needsQuotedKey AND is an unusual edge case; the
+    // prime detection should still apply transparently to its
+    // children.
+    const input = { '[0]': { p: 7 } };
+    expect(roundTrip(input)).toEqual(input);
+  });
+});

--- a/src/lexer/RomlLexer.ts
+++ b/src/lexer/RomlLexer.ts
@@ -203,16 +203,18 @@ export class RomlLexer {
       // Check for object start: key{
       const objectMatch = trimmedLine.match(/^(.+?)\{$/);
       if (objectMatch) {
-        const key = objectMatch[1];
+        const extracted = this.extractKey(objectMatch[1]);
         this.addToken(
           'OBJECT_START',
           trimmedLine,
           startOffset,
           lineNumber,
           undefined,
-          key,
+          extracted.key,
           undefined,
-          depth
+          depth,
+          extracted.wasQuoted,
+          extracted.hasPrimePrefix
         );
         i++;
         continue;
@@ -221,16 +223,18 @@ export class RomlLexer {
       // Check for array start: key[
       const arrayMatch = trimmedLine.match(/^(.+?)\[$/);
       if (arrayMatch) {
-        const key = arrayMatch[1];
+        const extracted = this.extractKey(arrayMatch[1]);
         this.addToken(
           'ARRAY_START',
           trimmedLine,
           startOffset,
           lineNumber,
           undefined,
-          key,
+          extracted.key,
           undefined,
-          depth
+          depth,
+          extracted.wasQuoted,
+          extracted.hasPrimePrefix
         );
         i++;
         continue;
@@ -259,34 +263,35 @@ export class RomlLexer {
     }
   }
 
+  /**
+   * Strip an optional leading `!` (prime marker) and surrounding double
+   * quotes from a raw key, returning the literal JSON key plus the
+   * structural metadata. Used by `parseKeyValueLine` for KEY_VALUE
+   * tokens and by `processLines` for OBJECT_START / ARRAY_START tokens
+   * so all token types surface clean keys with consistent flags.
+   */
+  private extractKey(keyPart: string): ExtractedKey {
+    let inner = keyPart;
+    let hasPrimePrefix = false;
+    if (inner.startsWith('!')) {
+      hasPrimePrefix = true;
+      inner = inner.substring(1);
+    }
+    const quotedKeyMatch = inner.match(/^"(.*)"$/);
+    if (quotedKeyMatch) {
+      return {
+        key: unescapeStringValue(quotedKeyMatch[1]),
+        wasQuoted: true,
+        hasPrimePrefix,
+      };
+    }
+    return { key: inner, wasQuoted: false, hasPrimePrefix };
+  }
+
   private parseKeyValueLine(
     line: string
   ): [string, unknown, string, boolean, boolean] | null {
-    // `extractKey` returns a structured result so each call site can
-    // explicitly thread the quoting / prime-prefix metadata into its
-    // own return tuple. Earlier iterations used closure side effects
-    // ("most recent call wins"), which silently broke if a branch
-    // happened to call extractKey more than once.
-    const extractKey = (keyPart: string): ExtractedKey => {
-      let inner = keyPart;
-      let hasPrimePrefix = false;
-      if (inner.startsWith('!')) {
-        hasPrimePrefix = true;
-        inner = inner.substring(1);
-      }
-      const quotedKeyMatch = inner.match(/^"(.*)"$/);
-      if (quotedKeyMatch) {
-        return {
-          key: unescapeStringValue(quotedKeyMatch[1]),
-          wasQuoted: true,
-          hasPrimePrefix,
-        };
-      }
-      // Unquoted: `inner` is the post-prefix key when there was a `!`,
-      // or the original `keyPart` otherwise. Either way, the leading
-      // prime marker (if any) has already been stripped here.
-      return { key: inner, wasQuoted: false, hasPrimePrefix };
-    };
+    const extractKey = (keyPart: string): ExtractedKey => this.extractKey(keyPart);
 
     // Check special cases FIRST before simple separator analysis
     // This prevents complex patterns from being incorrectly split by analyzeLineStructure

--- a/src/parser/RomlParser.ts
+++ b/src/parser/RomlParser.ts
@@ -179,27 +179,27 @@ export class RomlParser {
   private parseChildObject(token: RomlToken): RomlObjectNode | null {
     if (token.key === undefined) return null;
 
-    // Strip prime prefix from object key
-    let cleanKey = token.key;
-    if (token.key.startsWith('!')) {
+    // The lexer already stripped the prime prefix and surrounding
+    // quotes from `token.key`; just record whether a `!` was present
+    // so prime-validation can fire against the parent document.
+    if (token.keyHasPrimePrefix) {
       this.primesDetected = true;
-      cleanKey = token.key.substring(1);
     }
 
     this.advance();
-    const childObject = this.parseObject(cleanKey, (token.depth || 0) + 1);
+    const childObject = this.parseObject(token.key, (token.depth || 0) + 1);
     return childObject;
   }
 
   private parseChildArray(token: RomlToken): RomlArrayNode | null {
     if (token.key === undefined) return null;
 
-    // Strip prime prefix from array key
-    let cleanKey = token.key;
-    if (token.key.startsWith('!')) {
+    // The lexer already stripped the prime prefix and surrounding
+    // quotes from `token.key`; just record whether a `!` was present.
+    if (token.keyHasPrimePrefix) {
       this.primesDetected = true;
-      cleanKey = token.key.substring(1);
     }
+    const cleanKey = token.key;
 
     this.advance();
     const items: (RomlValueNode | RomlObjectNode | RomlArrayNode)[] = [];


### PR DESCRIPTION
## Summary

`KEY_VALUE` lines route the key through `formatKeyName` and the lexer unquotes via `extractKey`, but the encoder's other key-emit sites used the raw key:

- `convertObject`'s with-key branch (the `key{` opener)
- `convertArray`'s structured branch (the `key[` opener)
- `convertArray`'s primitive-array switch (`PIPES` / `BRACKETS` / `JSON_STYLE` / `COLON_DELIM`)

So an empty-string key with an object or array value silently disappeared:

```
{"":{}}     -> ROML -> {}
{"":[]}     -> ROML -> {}
```

And a key like `"a=b"` or `"<key>"` with an object value would also mis-tokenize because the raw `=` / `<` survived into the `OBJECT_START` line. Same family as #20.

## Three coordinated changes

**1. Encoder (`src/RomlConverter.ts`)**
- Format the key in `convertObject`'s with-key branch and `convertArray`'s structured branch.
- Format the key in all four primitive-array styles.
- `convertArray`'s complex-item path emits the structural `[N]{...}` opener directly, bypassing `convertObject`'s with-key branch — otherwise `[0]` would (correctly) get quoted by `needsQuotedKey`'s `[...]`-shape rule, but the lexer's `arrayItemMatch` regex only matches the unquoted form. The user's own `{"[0]": x}` keys still go through `convertObject` with-key and get quoted; only the structural use bypasses formatting.

**2. Lexer (`src/lexer/RomlLexer.ts`)**
- Hoist `extractKey` from a closure inside `parseKeyValueLine` to a private method on the class.
- Call it from the `OBJECT_START` and `ARRAY_START` token production sites so every token surfaces a clean key plus `keyWasQuoted` / `keyHasPrimePrefix` flags.

**3. Parser (`src/parser/RomlParser.ts`)**
- `parseChildObject` / `parseChildArray` no longer inspect `token.key.startsWith('!')`; they read `token.keyHasPrimePrefix` so the structural metadata stays consistent across token types.

## BC break

No external API change. New token producers populate the existing `keyWasQuoted` / `keyHasPrimePrefix` optional fields.

## Failing tests (added in this PR)

```ts
// src/__tests__/ObjectArrayStartKey.test.ts (10 tests)
it('round-trips an empty-string key whose value is an object', ...);
it('round-trips an empty-string key whose value is an array', ...);
it('round-trips a space-only key whose value is an object', ...);
it('round-trips a key containing `=` whose value is an object', ...);
it('round-trips a key containing `<` whose value is an object', ...);
it('round-trips a key containing `:` whose value is an array of objects', ...);
it('round-trips a quoted-key user-supplied `[0]` shape (still allowed as a regular key)', ...);
it('still round-trips a normal nested object (sanity)', ...);
it('still round-trips a normal nested array (sanity)', ...);
it('still preserves the prime prefix on an object-valued key whose key was quoted', ...);
```

Before fix: 5 of 10 fail. After fix: 10 of 10 pass.

## Files touched

- `src/RomlConverter.ts` — `formatKeyName` at five emit sites + structural `[N]{...}` direct-emit.
- `src/lexer/RomlLexer.ts` — hoisted `extractKey` private method, `OBJECT_START` / `ARRAY_START` wired through it.
- `src/parser/RomlParser.ts` — `parseChildObject` / `parseChildArray` use `token.keyHasPrimePrefix`.
- `src/__tests__/ObjectArrayStartKey.test.ts` — regression coverage.

## Test plan

- [x] `npm install && npm run build && npm run lint && npm test` — 327 tests pass (was 317 + 10 new), lint and build clean.
- [x] Smoke: `node -e 'const {RomlFile}=require("./dist/file/RomlFile.js"); console.log(JSON.stringify(RomlFile.romlToJson(RomlFile.jsonToRoml({"":{}}))));'` returns `{"":{}}` rather than `{}`.