### PR TITLE
fix(encoder): even-line boolean handler honors needs-quoted-key

### DIFF
--- a/src/RomlConverter.ts
+++ b/src/RomlConverter.ts
@@ -590,10 +590,17 @@ export class RomlConverter {
     // Alternating line behavior for different value types
     if (valueType === 'boolean') {
       if (isEvenLine) {
-        // Even lines: use equals notation with yes/no
+        // Even lines: use equals notation with yes/no. This handler
+        // bypasses `createSyntaxStyle` to render the literal `yes`/`no`
+        // without quoting, so it has to call `formatKeyName` itself —
+        // otherwise keys that need quoting (empty / whitespace /
+        // separator-char / `!`-prefix / `[N]`-shape) lose their
+        // quoting only when they land on an even-numbered line with
+        // a boolean value.
         return (key: string, value: unknown, features: LineFeatures) => {
           const prefix = features.containsPrime ? '!' : '';
-          return `${prefix}${key}=${value === true ? 'yes' : 'no'}`;
+          const formattedKey = formatKeyName(key, features.needsQuotedKey);
+          return `${prefix}${formattedKey}=${value === true ? 'yes' : 'no'}`;
         };
       } else {
         // Odd lines: use bracket notation

--- a/src/__tests__/EvenLineBooleanKey.test.ts
+++ b/src/__tests__/EvenLineBooleanKey.test.ts
@@ -1,0 +1,60 @@
+import { RomlFile } from '../file/RomlFile';
+
+describe('Even-line boolean handler honors needs-quoted-key', () => {
+  // Regression: `selectSyntax`'s even-line boolean branch is the one
+  // syntax that bypasses `createSyntaxStyle` entirely — it returns an
+  // ad-hoc closure that emits `${prefix}${key}=${yes/no}`. That
+  // closure used the raw `key` instead of running it through
+  // `formatKeyName`, so a key that needed quoting (empty, whitespace,
+  // separator-char, `!`-prefix, `[N]`-shape) lost its quoting only
+  // when it landed on an even-numbered line with a boolean value.
+  //
+  // The shape only manifests with two-or-more keys because the FIRST
+  // key of an object lands on counter=1 (odd), which uses the
+  // `BRACKETS` style routed through `createSyntaxStyle` correctly.
+  // The second key on counter=2 (even) hits the broken inline path.
+
+  function roundTrip(input: unknown): unknown {
+    return RomlFile.romlToJson(RomlFile.jsonToRoml(input));
+  }
+
+  it('round-trips an even-line space-only key with a boolean value', () => {
+    // First entry forces the second to land on an even line.
+    const input = { first: true, ' ': false };
+    expect(roundTrip(input)).toEqual(input);
+  });
+
+  it('round-trips an even-line empty-string key with a boolean value', () => {
+    const input = { first: true, '': false };
+    expect(roundTrip(input)).toEqual(input);
+  });
+
+  it('round-trips an even-line key containing `=` with a boolean value', () => {
+    const input = { first: true, 'a=b': false };
+    expect(roundTrip(input)).toEqual(input);
+  });
+
+  it('round-trips an even-line `!`-prefix key with a boolean value', () => {
+    const input = { first: true, '!warn': true };
+    expect(roundTrip(input)).toEqual(input);
+  });
+
+  it('still round-trips two ordinary boolean entries (sanity)', () => {
+    const input = { foo: true, bar: false };
+    expect(roundTrip(input)).toEqual(input);
+  });
+
+  it('round-trips multiple stress-keyed boolean entries in a row', () => {
+    // Forces several different even-line cases through the inline
+    // handler in one document.
+    const input = {
+      a: true,
+      ' ': false,
+      b: true,
+      '': true,
+      c: false,
+      'x=y': false,
+    };
+    expect(roundTrip(input)).toEqual(input);
+  });
+});


### PR DESCRIPTION
## Summary

`selectSyntax`'s even-line boolean branch is the one syntax that bypasses `createSyntaxStyle` entirely — it returns an ad-hoc closure that renders the literal `yes`/`no` (with no value-quoting) and so can't reuse the helper. That closure used the raw `key` instead of running it through `formatKeyName`, so any key that needed quoting (empty / whitespace / separator-char / `!`-prefix / `[N]`-shape) lost its quoting *only* when it landed on an even-numbered line with a boolean value:

```
{first: true, " ": false}        // " " on counter=2 (even)
  -> ROML -> Parse error: Duplicate key "" at line 3
     (the leading space confuses the lexer into treating `=no`
      as a KEY_VALUE with an empty key)
```

The first key of an object lands on counter=1 (odd) and uses `SYNTAX_STYLES.BRACKETS`, which routes through `createSyntaxStyle` and formats correctly. Only the second-and-beyond entries hit the broken inline path. Same family as #20 / #21.

Fix: add `formatKeyName` to the inline closure.

## BC break

No.

## Failing tests (added in this PR)

```ts
// src/__tests__/EvenLineBooleanKey.test.ts (6 tests)
it('round-trips an even-line space-only key with a boolean value', () => {
  expect(rt({ first: true, ' ': false })).toEqual({ first: true, ' ': false });
});
it('round-trips an even-line empty-string key with a boolean value', ...);
it('round-trips an even-line key containing `=` with a boolean value', ...);
it('round-trips an even-line `!`-prefix key with a boolean value', ...);
it('still round-trips two ordinary boolean entries (sanity)', ...);
it('round-trips multiple stress-keyed boolean entries in a row', ...);
```

Before fix: 4 of 6 fail. After fix: 6 of 6 pass.

## Files touched

- `src/RomlConverter.ts` — one new line in the even-line boolean closure.
- `src/__tests__/EvenLineBooleanKey.test.ts` — regression coverage.

## Test plan

- [x] `npm install && npm run build && npm run lint && npm test` — 333 tests pass (was 327 + 6 new), lint and build clean.
- [x] Smoke: `node -e 'const {RomlFile}=require("./dist/file/RomlFile.js"); console.log(JSON.stringify(RomlFile.romlToJson(RomlFile.jsonToRoml({first:true," ":false}))));'` returns `{"first":true," ":false}` rather than throwing a parse error.