### PR TITLE
fix(encoder): quote keys containing backslash

### DIFF
--- a/src/RomlConverter.ts
+++ b/src/RomlConverter.ts
@@ -203,6 +203,14 @@ export class RomlConverter {
     // Check for keys with quotes (need escaping)
     if (key.includes('"')) return true;
 
+    // Backslash collides with the lexer's escape-aware separator
+    // finder (`\` swallows the next char while scanning for the
+    // KEY_VALUE separator outside quotes), so a raw `\` in a key
+    // would lose the actual separator. Routing through the QUOTED
+    // form lets `escapeForRoml` double the backslash and the
+    // lexer's `unescapeStringValue` reverse it cleanly.
+    if (key.includes('\\')) return true;
+
     // Check for keys that start with comment-like syntax
     if (key.startsWith('#') || key.startsWith('//')) return true;
 

--- a/src/__tests__/BackslashInKey.test.ts
+++ b/src/__tests__/BackslashInKey.test.ts
@@ -1,0 +1,55 @@
+import { RomlFile } from '../file/RomlFile';
+
+describe('Backslash in key', () => {
+  // Regression: `RomlConverter.needsQuotedKey` didn't flag keys
+  // containing `\`, so the encoder emitted the raw byte. The lexer's
+  // `findSeparatorOutsideQuotes` then treated `\` as an escape that
+  // swallows the next char — e.g. a key `\` with an AMPERSAND-style
+  // number value `0` rendered as `&\&0`, where `\&` was consumed as
+  // the escape and the actual `&` separator was lost. Round-trip
+  // dropped the key entirely:
+  //
+  //   {"\\": 0}     -> ROML -> {}
+  //
+  // Fix: `needsQuotedKey` returns true for any key containing `\`,
+  // routing it through the QUOTED form where `escapeForRoml`
+  // doubles the backslash and the lexer's `unescapeStringValue`
+  // reverses it cleanly.
+
+  function roundTrip(input: unknown): unknown {
+    return RomlFile.romlToJson(RomlFile.jsonToRoml(input));
+  }
+
+  it('round-trips a single-backslash key with a numeric value', () => {
+    expect(roundTrip({ '\\': 0 })).toEqual({ '\\': 0 });
+  });
+
+  it('round-trips a single-backslash key with a string value', () => {
+    expect(roundTrip({ '\\': 'hello' })).toEqual({ '\\': 'hello' });
+  });
+
+  it('round-trips a single-backslash key with a boolean value', () => {
+    expect(roundTrip({ '\\': true })).toEqual({ '\\': true });
+  });
+
+  it('round-trips a backslash mid-key', () => {
+    expect(roundTrip({ 'a\\b': 1 })).toEqual({ 'a\\b': 1 });
+  });
+
+  it('round-trips a key that is two backslashes', () => {
+    expect(roundTrip({ '\\\\': 1 })).toEqual({ '\\\\': 1 });
+  });
+
+  it('round-trips a `!`-prefixed backslash key (interaction with prime marker)', () => {
+    expect(roundTrip({ '!\\': 1 })).toEqual({ '!\\': 1 });
+  });
+
+  it('round-trips an array of objects with backslash keys', () => {
+    const input = [{ '\\': 0 }, { '\\': 1 }];
+    expect(roundTrip(input)).toEqual(input);
+  });
+
+  it('still preserves backslash-containing string values (no regression)', () => {
+    expect(roundTrip({ a: 'b\\c' })).toEqual({ a: 'b\\c' });
+  });
+});

--- a/src/__tests__/RoundTripFuzz.test.ts
+++ b/src/__tests__/RoundTripFuzz.test.ts
@@ -165,9 +165,9 @@ describe('Round-trip property tests (fast-check)', () => {
  *     `__roml_items__` (array value) or `__roml_value__` (any value)
  *     is structurally indistinguishable from a wrap of a non-object
  *     root after parsing.
- *  2. Backslash in a key — `needsQuotedKey` doesn't flag `\`, so the
- *     raw byte falls into the lexer's escape-aware separator finder
- *     and swallows the next char.
+ *  2. (Resolved — `needsQuotedKey` now flags `\`-containing keys so
+ *     the encoder routes them through QUOTED. Number kept for
+ *     stable cross-referencing in this docstring.)
  *  3. Single-element primitive arrays — `key||x||` is structurally
  *     ambiguous with scalar `key||x||` in PIPES / JSON / COLON_DELIM
  *     styles. Only BRACKETS appends a `<>` marker for arity-1.
@@ -325,8 +325,7 @@ function hasKnownLimitation(input: unknown): boolean {
   }
 
   for (const [key, value] of Object.entries(obj)) {
-    // (2) Backslash in key.
-    if (key.includes('\\')) return true;
+    // (2) Backslash in key — resolved; no constraint needed.
 
     // (3) Single-element primitive arrays.
     if (


### PR DESCRIPTION
## Summary

`RomlConverter.needsQuotedKey` didn't flag keys containing `\`, so the encoder emitted the raw byte. The lexer's `findSeparatorOutsideQuotes` treats `\` as an escape that swallows the next char while scanning for the KEY_VALUE separator outside quotes — so a key `\` with an AMPERSAND-style number value `0` rendered as `&\&0`, where `\&` was consumed as the escape and the actual `&` separator was lost. The line was silently dropped:

```
{"\\": 0}    -> ROML -> {}
{"a\\b": 1}  -> ROML -> {}
```

Routing the key through the QUOTED form fixes both halves: the existing `escapeForRoml` doubles the backslash on encode (`\\`) and the lexer's `unescapeStringValue` reverses it on decode. Both were already paired correctly; we just needed the key to actually take the QUOTED path.

Limitation #2 from the fast-check fuzz file (#23) is now resolved; its constraint in `hasKnownLimitation` is removed and the fuzz arbitraries (which already generate `\` via `stressString`) cover the case under the pinned seed.

## BC break

No.

## Failing tests (added in this PR)

```ts
// src/__tests__/BackslashInKey.test.ts (8 tests)
it('round-trips a single-backslash key with a numeric value', () => {
  expect(rt({ '\\': 0 })).toEqual({ '\\': 0 });
});
it('round-trips a single-backslash key with a string value', ...);
it('round-trips a single-backslash key with a boolean value', ...);
it('round-trips a backslash mid-key', ...);
it('round-trips a key that is two backslashes', ...);
it('round-trips a `!`-prefixed backslash key (interaction with prime marker)', ...);
it('round-trips an array of objects with backslash keys', ...);
it('still preserves backslash-containing string values (no regression)', ...);
```

Before fix: 3 of 8 fail (the others happen to round-trip via style selection that doesn't pick AMPERSAND). After fix: 8 of 8 pass.

## Files touched

- `src/RomlConverter.ts` — one new branch in `needsQuotedKey`.
- `src/__tests__/BackslashInKey.test.ts` — regression coverage.
- `src/__tests__/RoundTripFuzz.test.ts` — drop limitation #2 from `hasKnownLimitation`; mark resolved in the docstring counter.

## Test plan

- [x] `npm install && npm run build && npm run lint && npm test` — 345 tests pass (was 337 + 8 new), lint and build clean.
- [x] Fuzz still passes after dropping the constraint (pinned seed `20260507`, 100 runs per property).
- [x] Smoke: `node -e 'import("./dist/file/RomlFile.js").then(m=>console.log(JSON.stringify(m.RomlFile.romlToJson(m.RomlFile.jsonToRoml({"\\":0})))))'` returns `{"\\":0}` rather than `{}`.

This is the first follow-up landing one of the 15 limitations documented in #23. Of the 14 remaining, the natural next pairs (smallest blast radius first) are #7 + #8 (type-aware syntax selection) or #5 + #6 (quote-aware regex parsing).

https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV)_