### PR TITLE
fix(encoder): make selectSyntax type-aware (limitations #7 + #8)

### DIFF
--- a/src/RomlConverter.ts
+++ b/src/RomlConverter.ts
@@ -589,9 +589,29 @@ export class RomlConverter {
     const valueType = typeof value;
     const valueLength = String(value).length;
 
-    // Check semantic categories first (apply to both odd and even lines)
+    // Special values (null, undefined, empty string) take precedence
+    // — `convertValue` passes the sentinel string `'__NULL__'` /
+    // `'__UNDEFINED__'` / `''` here, but they need a style that emits
+    // the sentinel UNQUOTED so the parser recognises them as the
+    // original null / undefined / empty-string. Without this gate the
+    // string-branch below would pick a quoting style for them on
+    // odd-line vowel-starting keys (limitation #8).
+    if (lineFeatures.isSpecialValue) {
+      if (isEvenLine) {
+        return EVEN_LINE_STYLES.DOLLAR;
+      } else {
+        return SYNTAX_STYLES.FAKE_COMMENT;
+      }
+    }
+
+    // Check semantic categories first (apply to both odd and even lines).
+    // Only apply for true string values — the override forces a style
+    // based on key name, but several semantic styles (notably PERSONAL
+    // → QUOTED) wrap the value in double quotes and would coerce
+    // non-strings (booleans, numbers) into string round-trips
+    // (limitation #7).
     const semanticStyle = this.getSemanticStyle(key);
-    if (semanticStyle && !isEvenLine) {
+    if (semanticStyle && !isEvenLine && valueType === 'string') {
       return SYNTAX_STYLES[semanticStyle];
     }
 
@@ -643,15 +663,6 @@ export class RomlConverter {
         } else {
           return SYNTAX_STYLES.FAKE_COMMENT;
         }
-      }
-    }
-
-    // Handle special values (null, undefined, empty)
-    if (lineFeatures.isSpecialValue) {
-      if (isEvenLine) {
-        return EVEN_LINE_STYLES.DOLLAR;
-      } else {
-        return SYNTAX_STYLES.FAKE_COMMENT;
       }
     }
 

--- a/src/__tests__/RoundTrip.test.ts
+++ b/src/__tests__/RoundTrip.test.ts
@@ -175,21 +175,25 @@ describe('ROML Round-Trip Conversion Tests', () => {
   describe('Syntax Style Verification', () => {
     it('should use semantic-based syntax styles with alternating behavior', () => {
       const data = {
-        name: 'Test', // Line 1 (odd): Personal -> quoted
-        active: true, // Line 2 (even): Status -> equals yes/no
-        tags: ['a', 'b'], // Line 3 (odd): Collection -> BRACKETS
-        id: 'abc123', // Line 4 (even): Technical -> tilde (vowel-starting)
-        salary: 50000, // Line 5 (odd): Financial -> fake comment
+        name: 'Test', // Line 1 (odd): PERSONAL + string -> quoted
+        active: true, // Line 2 (even): boolean -> equals yes/no
+        tags: ['a', 'b'], // Line 3 (odd): array (semantic only applies for strings)
+        id: 'abc123', // Line 4 (even): vowel-starting + string -> tilde
+        salary: 50000, // Line 5 (odd): number -> ampersand (semantic skipped for non-strings)
       };
 
       const romlContent = RomlFile.jsonToRoml(data);
 
-      // Check for expected syntax patterns with alternating line behavior
-      expect(romlContent).toContain('name="Test"'); // Line 1: Quoted style
-      expect(romlContent).toContain('active=yes'); // Line 2: Even line boolean
-      expect(romlContent).toContain('tags<a><b>'); // Line 3: Bracket array style
-      expect(romlContent).toContain('id~abc123'); // Line 4: Even line, vowel-starting
-      expect(romlContent).toContain('//salary//50000'); // Line 5: Fake comment style
+      // The semantic-category override only applies when the value
+      // is a string — non-strings (boolean / number / array) defer
+      // to the value-type rules so they don't get stringified by
+      // QUOTED-mapped categories like PERSONAL or FAKE_COMMENT-
+      // mapped FINANCIAL on values that aren't actually strings.
+      expect(romlContent).toContain('name="Test"'); // Line 1: PERSONAL + string -> quoted
+      expect(romlContent).toContain('active=yes'); // Line 2: even-line boolean
+      expect(romlContent).toContain('tags<a><b>'); // Line 3: bracket array style (hash-selected)
+      expect(romlContent).toContain('id~abc123'); // Line 4: vowel-starting key + string
+      expect(romlContent).toContain('&salary&50000'); // Line 5: number -> ampersand
     });
   });
 
@@ -354,18 +358,24 @@ flag4=no`;
 
     it('should apply even-line styles to special values', () => {
       const data = {
-        value1: null, // Line 1 (odd) - fake comment style
-        value2: null, // Line 2 (even) - equals style for special values
-        value3: '', // Line 3 (odd) - fake comment style
-        value4: '', // Line 4 (even) - equals style for special values
+        value1: null, // Line 1 (odd): special value -> fake comment
+        value2: null, // Line 2 (even): special value -> dollar
+        value3: '', // Line 3 (odd): empty string -> fake comment
+        value4: '', // Line 4 (even): empty string -> dollar
       };
 
       const romlContent = RomlFile.jsonToRoml(data);
 
-      expect(romlContent).toContain('//value1//__NULL__'); // Odd line
-      expect(romlContent).toContain('value2=__NULL__'); // Even line: equals for special values
-      expect(romlContent).toContain('//value3//""'); // Odd line - empty string preserved as quoted
-      expect(romlContent).toContain('value4=""'); // Even line: equals style with quoted empty string
+      // Special values (null, '') are routed through the dedicated
+      // syntax styles before any value-type or semantic dispatch:
+      // FAKE_COMMENT on odd lines, DOLLAR on even. This guarantees
+      // the sentinel emits UNQUOTED so the parser recognises it
+      // rather than treating it as the literal string "__NULL__"
+      // / "".
+      expect(romlContent).toContain('//value1//__NULL__'); // odd: fake-comment
+      expect(romlContent).toContain('value2$__NULL__'); // even: dollar
+      expect(romlContent).toContain('//value3//""'); // odd: empty string preserved as quoted in fake-comment
+      expect(romlContent).toContain('value4$""'); // even: dollar with empty-string quoted
     });
   });
 

--- a/src/__tests__/RoundTripFuzz.test.ts
+++ b/src/__tests__/RoundTripFuzz.test.ts
@@ -179,14 +179,12 @@ describe('Round-trip property tests (fast-check)', () => {
  *  6. Quoted-key + `:`-containing key in any KEY_VALUE form: the
  *     colon-array regex in `parseSpecialCases` is not quote-aware,
  *     causing `"::"=value` to be misread as a colon-delimited array.
- *  7. Semantic-category key (`name`, `id`, `salary`, ...) with a
- *     non-string value: the encoder routes these through `QUOTED` or
- *     `FAKE_COMMENT` regardless of value type, so `{name: false}`
- *     becomes `name="false"` and round-trips as the string `"false"`.
- *  8. `null` values with a vowel-starting key on an odd line: the
- *     encoder picks `QUOTED` for the `__NULL__` sentinel string,
- *     emitting `key="__NULL__"` which round-trips as the string
- *     `"__NULL__"` rather than null.
+ *  7. (Resolved — `selectSyntax` now requires `valueType === 'string'`
+ *     before applying the semantic-category override; non-string
+ *     values defer to the value-type branches.)
+ *  8. (Resolved — `isSpecialValue` is checked ahead of the type-
+ *     specific branches, so null / undefined / empty-string sentinels
+ *     always pick a non-quoting style regardless of the key shape.)
  *  9. BRACKETS-style primitive array containing a string item with
  *     `>` in it: the encoder doesn't escape `>` inside `<value>`
  *     items, so the lexer's `<([^>]*)>` regex splits at the wrong
@@ -347,16 +345,7 @@ function hasKnownLimitation(input: unknown): boolean {
     // (6) Quoted-key + `:`-in-key.
     if (key.includes(':')) return true;
 
-    // (7) Semantic-category key with a non-string, non-object value.
-    if (
-      SEMANTIC_KEYS.has(key.toLowerCase()) &&
-      (typeof value === 'boolean' || typeof value === 'number' || value === null)
-    ) {
-      return true;
-    }
-
-    // (8) Null value with a vowel-starting key.
-    if (value === null && /^[aeiouAEIOU]/.test(key)) return true;
+    // (7) and (8) resolved; no constraints needed.
 
     // (9) Array containing a string with `>` (BRACKETS-style escape).
     if (

--- a/src/__tests__/TypeAwareSyntaxSelection.test.ts
+++ b/src/__tests__/TypeAwareSyntaxSelection.test.ts
@@ -1,0 +1,94 @@
+import { RomlFile } from '../file/RomlFile';
+
+describe('Type-aware syntax selection', () => {
+  // Regression for fuzz limitations #7 and #8.
+  //
+  // #7: `selectSyntax`'s semantic-category override fired regardless
+  // of value type. PERSONAL → QUOTED, which wraps the value in
+  // double quotes, so a non-string value gets stringified:
+  //
+  //   {name: false}  -> name="false"  -> {"name": "false"}
+  //   {name: 42}     -> name="42"     -> {"name": "42"}
+  //   {name: null}   -> name="__NULL__" -> {"name": "__NULL__"}
+  //
+  // #8: `null` is passed to `selectSyntax` as the sentinel string
+  // `'__NULL__'`, so it took the string branch instead of the
+  // special-value branch. With a vowel-starting key on an odd line
+  // that branch picks QUOTED, again wrapping the sentinel:
+  //
+  //   {u: null}      -> u="__NULL__" -> {"u": "__NULL__"}
+  //
+  // Fix:
+  //  - Reorder `isSpecialValue` ahead of the type-specific branches
+  //    so null / undefined / empty-string sentinels always pick a
+  //    style that emits the marker UNQUOTED (FAKE_COMMENT on odd
+  //    lines, DOLLAR on even).
+  //  - Constrain the semantic-category override to `valueType ===
+  //    'string'` so it only applies to true string values; non-string
+  //    values fall through to the value-type branches (BRACKETS for
+  //    booleans, AMPERSAND/COLON for numbers, etc.).
+
+  function roundTrip(input: unknown): unknown {
+    return RomlFile.romlToJson(RomlFile.jsonToRoml(input));
+  }
+
+  describe('limitation #7: semantic-category override for non-string values', () => {
+    it('round-trips `name: false` (PERSONAL → would force QUOTED)', () => {
+      expect(roundTrip({ name: false })).toEqual({ name: false });
+    });
+
+    it('round-trips `name: 42` (PERSONAL → would force QUOTED)', () => {
+      expect(roundTrip({ name: 42 })).toEqual({ name: 42 });
+    });
+
+    it('round-trips `name: null` (combines #7 and #8)', () => {
+      expect(roundTrip({ name: null })).toEqual({ name: null });
+    });
+
+    it('round-trips `id: true` (TECHNICAL → AMPERSAND for non-string)', () => {
+      expect(roundTrip({ id: true })).toEqual({ id: true });
+    });
+
+    it('round-trips `salary: 50000` (FINANCIAL — preserved as number)', () => {
+      expect(roundTrip({ salary: 50000 })).toEqual({ salary: 50000 });
+    });
+
+    it('still round-trips `name: "Robert"` (PERSONAL strings still quote)', () => {
+      expect(roundTrip({ name: 'Robert' })).toEqual({ name: 'Robert' });
+    });
+  });
+
+  describe('limitation #8: null with vowel-starting key', () => {
+    it('round-trips `u: null` (single-letter vowel key)', () => {
+      expect(roundTrip({ u: null })).toEqual({ u: null });
+    });
+
+    it('round-trips `a: null`', () => {
+      expect(roundTrip({ a: null })).toEqual({ a: null });
+    });
+
+    it('round-trips `email: null` (vowel-start + PERSONAL semantic)', () => {
+      expect(roundTrip({ email: null })).toEqual({ email: null });
+    });
+
+    it('round-trips multiple vowel-start null keys in one object', () => {
+      const input = { i: null, e: null, o: null };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('still round-trips a consonant-key null (no regression)', () => {
+      expect(roundTrip({ x: null })).toEqual({ x: null });
+    });
+
+    it('round-trips a null at the second-and-beyond entry positions', () => {
+      // Forces the null to land on counter=2 (even line, DOLLAR).
+      const input = { first: 1, u: null, third: 'x' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips null deeply nested under vowel-starting keys', () => {
+      const input = { a: { o: { u: null } } };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Two related bugs in `RomlConverter.selectSyntax`, both surfaced by the fast-check fuzz (#23) and constrained out by `hasKnownLimitation` until now.

**#7 — Semantic-category override forced regardless of value type.** The override picks a syntax family based purely on key name (PERSONAL → QUOTED, FINANCIAL → FAKE_COMMENT, etc.). For non-string values that override silently coerced the value to a string round-trip:

```
{name: false}  -> name="false"        -> {"name": "false"}
{name: 42}     -> name="42"           -> {"name": "42"}
{name: null}   -> name="__NULL__"     -> {"name": "__NULL__"}
```

**#8 — Null with vowel-starting key.** `convertValue` passes `null` to `selectSyntax` as the sentinel string `'__NULL__'`, so it took the string-branch instead of the dedicated special-value branch. With a vowel-starting key on an odd line that branch chose `QUOTED`, again wrapping the sentinel in quotes:

```
{u: null}  -> u="__NULL__"  -> {"u": "__NULL__"}
```

The two share one root cause: the special-value / value-type branches were sequenced after gates that didn't consider the actual JS type. Two coordinated changes in `selectSyntax`:

1. **Reorder `isSpecialValue` ahead of every other branch** — null / undefined / empty-string sentinels always pick a non-quoting style (`FAKE_COMMENT` on odd lines, `DOLLAR` on even). The duplicated lower block is removed (now unreachable).
2. **Constrain the semantic-category override to `valueType === 'string'`** — non-strings (boolean / number / array) defer to the value-type rules so they don't get stringified by QUOTED-mapped categories.

## BC break

**Soft yes** — the encoder picks different syntax bytes for two shapes the format previously produced:
- `{salary: 50000}` was `//salary//50000` (FAKE_COMMENT via FINANCIAL); now `&salary&50000` (AMPERSAND for odd-line number). Both round-trip correctly; the new form is type-consistent with non-semantic numeric keys.
- `{value2: null}` on an even line was `value2=__NULL__` (the test was passing for the wrong reason — the special-value branch was unreachable); now `value2$__NULL__` (DOLLAR). The lexer parses both equally well.

Two existing tests in `RoundTrip.test.ts` asserted the buggy output bytes; updated to match the fixed behavior with comments explaining the intent.

## Failing tests (added in this PR)

```ts
// src/__tests__/TypeAwareSyntaxSelection.test.ts (13 tests)
describe('limitation #7: semantic-category override for non-string values', () => {
  it('round-trips `name: false` (PERSONAL → would force QUOTED)', ...);
  it('round-trips `name: 42` (PERSONAL → would force QUOTED)', ...);
  it('round-trips `name: null` (combines #7 and #8)', ...);
  it('round-trips `id: true` (TECHNICAL → AMPERSAND for non-string)', ...);
  it('round-trips `salary: 50000` (FINANCIAL — preserved as number)', ...);
  it('still round-trips `name: "Robert"` (PERSONAL strings still quote)', ...);
});
describe('limitation #8: null with vowel-starting key', () => {
  it('round-trips `u: null` (single-letter vowel key)', ...);
  it('round-trips `a: null`', ...);
  it('round-trips `email: null` (vowel-start + PERSONAL semantic)', ...);
  it('round-trips multiple vowel-start null keys in one object', ...);
  it('still round-trips a consonant-key null (no regression)', ...);
  it('round-trips a null at the second-and-beyond entry positions', ...);
  it('round-trips null deeply nested under vowel-starting keys', ...);
});
```

Before fix: 8 of 13 fail. After fix: 13 of 13 pass.

## Files touched

- `src/RomlConverter.ts` — `selectSyntax` reordered + semantic gate narrowed.
- `src/__tests__/TypeAwareSyntaxSelection.test.ts` — regression coverage.
- `src/__tests__/RoundTrip.test.ts` — two assertion updates to match the fixed (correct) encoder bytes.
- `src/__tests__/RoundTripFuzz.test.ts` — drop limitations #7 and #8 from `hasKnownLimitation`; mark resolved in the docstring counter.

## Test plan

- [x] `npm install && npm run build && npm run lint && npm test` — 358 tests pass (was 345 + 13 new), lint and build clean.
- [x] Fuzz still passes with both constraints removed (pinned seed `20260507`, 100 runs per property).
- [x] Smoke: `node -e 'import("./dist/file/RomlFile.js").then(m=>console.log(JSON.stringify(m.RomlFile.romlToJson(m.RomlFile.jsonToRoml({name:false,u:null})))))'` returns `{"name":false,"u":null}` rather than `{"name":"false","u":"__NULL__"}`.

Of the original 15 fuzz limitations, this PR resolves #7 and #8. Three limitations remain in the smaller-fix range: #5 + #6 (quote-aware regex parsing) and #10 (empty-quoted-value regex). The architectural ones (#1 wrapper collision, #3 single-element array ambiguity) and the per-style item escaping (#9, #11, #14) are larger.

https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV)_