### PR TITLE
docs: address post-merge Copilot comments from PR #25

### DIFF
--- a/src/RomlConverter.ts
+++ b/src/RomlConverter.ts
@@ -604,12 +604,13 @@ export class RomlConverter {
       }
     }
 
-    // Check semantic categories first (apply to both odd and even lines).
-    // Only apply for true string values — the override forces a style
-    // based on key name, but several semantic styles (notably PERSONAL
-    // → QUOTED) wrap the value in double quotes and would coerce
-    // non-strings (booleans, numbers) into string round-trips
-    // (limitation #7).
+    // Check semantic categories. The override applies only on odd
+    // lines (the alternating-style design reserves even lines for
+    // the value-type rules) and only for true string values — the
+    // override forces a style based on key name, but several semantic
+    // styles (notably PERSONAL → QUOTED) wrap the value in double
+    // quotes and would coerce non-strings (booleans, numbers) into
+    // string round-trips (limitation #7).
     const semanticStyle = this.getSemanticStyle(key);
     if (semanticStyle && !isEvenLine && valueType === 'string') {
       return SYNTAX_STYLES[semanticStyle];

--- a/src/__tests__/TypeAwareSyntaxSelection.test.ts
+++ b/src/__tests__/TypeAwareSyntaxSelection.test.ts
@@ -45,7 +45,11 @@ describe('Type-aware syntax selection', () => {
       expect(roundTrip({ name: null })).toEqual({ name: null });
     });
 
-    it('round-trips `id: true` (TECHNICAL → AMPERSAND for non-string)', () => {
+    it('round-trips `id: true` (TECHNICAL semantic skipped for non-string; falls through to boolean branch)', () => {
+      // `id` is in the TECHNICAL category which would normally map
+      // to AMPERSAND, but the type-aware gate skips the override for
+      // non-strings so a boolean value goes through the boolean
+      // branch instead (BRACKETS on odd lines / `=yes|no` on even).
       expect(roundTrip({ id: true })).toEqual({ id: true });
     });
 


### PR DESCRIPTION
## Summary

PR #25 merged before two Copilot-review-comment doc fixes landed. This PR carries them across.

Both are pure documentation; no code-behavior change.

1. **`src/RomlConverter.ts:611`** — the comment above the semantic-category gate said the override applies to "both odd and even lines", but the actual condition is `!isEvenLine` so it only fires on odd lines. Reworded to match: "applies only on odd lines… and only for true string values".

2. **`src/__tests__/TypeAwareSyntaxSelection.test.ts:48`** — the test name claimed `{ id: true }` exercises "TECHNICAL → AMPERSAND for non-string", but with the new `valueType === 'string'` gate the override is skipped entirely and the boolean value goes through the boolean branch (BRACKETS on odd lines / `=yes|no` on even). Updated the test name and added an inline comment describing what's actually being asserted.

## BC break

No.

## Files touched

- `src/RomlConverter.ts` — comment-only.
- `src/__tests__/TypeAwareSyntaxSelection.test.ts` — test-name + inline-comment-only.

## Test plan

- [x] `npm install && npm run build && npm run lint && npm test` — 358 tests pass (unchanged from #25), lint and build clean.

https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV)_