### PR TITLE
fix(lexer): make bracket and colon-array parsing quote-aware (#5 + #6)

### DIFF
--- a/src/__tests__/QuoteAwareRegexes.test.ts
+++ b/src/__tests__/QuoteAwareRegexes.test.ts
@@ -83,5 +83,25 @@ describe('Quote-aware lexer regexes', () => {
       const input = { items: ['a', 'b', 'c', 'd'] };
       expect(roundTrip(input)).toEqual(input);
     });
+
+    it('does not steal an EQUALS-style string value containing colons', () => {
+      // Surfaced by Copilot review on PR #27: the colon-array branch
+      // ran before the regular separator scan and didn't check for
+      // an earlier KEY_VALUE separator (`=`, `~`, etc.) outside
+      // quotes. So `y=a:b:c` (EQUALS string with colons in the
+      // value) would be misread as a 2-item colon-array. Now the
+      // colon-array branch only fires when no earlier separator
+      // outside quotes appears before the first `:`.
+      const input = { x: 0, y: 'a:b:c' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('does not steal a TILDE-style string value containing colons', () => {
+      // `i` is vowel-starting → encoder uses TILDE on even line.
+      // The TILDE separator must take precedence over `:`s in the
+      // value.
+      const input = { x: 0, i: 'a:b:c' };
+      expect(roundTrip(input)).toEqual(input);
+    });
   });
 });

--- a/src/__tests__/QuoteAwareRegexes.test.ts
+++ b/src/__tests__/QuoteAwareRegexes.test.ts
@@ -1,0 +1,87 @@
+import { RomlFile } from '../file/RomlFile';
+
+describe('Quote-aware lexer regexes', () => {
+  // Regression for fuzz limitations #5 and #6.
+  //
+  // #5 — Bracket regex `^(.+?)<(.+)>$` (in both `analyzeLineStructure`
+  // and `parseSpecialCases`) wasn't quote-aware. A quoted key
+  // containing `<` plus a boolean value rendered as `"<"<false>`,
+  // and the regex split at the FIRST `<` (inside the key's quotes)
+  // instead of the structural `<` separator. Round-trip mangled the
+  // key/value:
+  //
+  //   {"<": false}  -> "<"<false>  -> {"\"": "\"<false"}  // wrong
+  //
+  // #6 — Colon-array regex `^(.+?):(.+)$` in `parseSpecialCases`
+  // claimed any line with two `:`s as a colon-delimited array,
+  // even when the first `:` was inside a quoted key. So a
+  // `"::"=value` (legitimate KEY_VALUE with key `::`) was misread
+  // as a colon-array with key `"`:
+  //
+  //   {"::": null} (nested under another key) -> "::"=__NULL__
+  //   -> {"\"": ["", "\"=__NULL__"]}  // wrong
+  //
+  // Fix: replace both regexes with `findSeparatorOutsideQuotes`
+  // (which already exists for AMPERSAND parsing) so the key/value
+  // split happens at the structural separator, not at a separator
+  // hidden inside a quoted key.
+
+  function roundTrip(input: unknown): unknown {
+    return RomlFile.romlToJson(RomlFile.jsonToRoml(input));
+  }
+
+  describe('limitation #5: bracket regex quote-awareness', () => {
+    it('round-trips `{"<": false}` (single < in key with boolean)', () => {
+      expect(roundTrip({ '<': false })).toEqual({ '<': false });
+    });
+
+    it('round-trips `{">": true}` (single > in key with boolean)', () => {
+      expect(roundTrip({ '>': true })).toEqual({ '>': true });
+    });
+
+    it('round-trips `{"<key>": true}` (key with surrounding angle brackets)', () => {
+      expect(roundTrip({ '<key>': true })).toEqual({ '<key>': true });
+    });
+
+    it('round-trips a key containing < at multiple positions with a boolean value', () => {
+      expect(roundTrip({ 'a<b<c': true })).toEqual({ 'a<b<c': true });
+    });
+
+    it('still round-trips an ordinary boolean (sanity)', () => {
+      expect(roundTrip({ active: true, idle: false })).toEqual({
+        active: true,
+        idle: false,
+      });
+    });
+  });
+
+  describe('limitation #6: colon-array regex quote-awareness', () => {
+    it('round-trips `{"::": null}` (key is two colons)', () => {
+      expect(roundTrip({ '::': null })).toEqual({ '::': null });
+    });
+
+    it('round-trips `{"::": "value"}` (string value)', () => {
+      expect(roundTrip({ '::': 'value' })).toEqual({ '::': 'value' });
+    });
+
+    it('round-trips `{":k:": 1}` (colons surrounding the key)', () => {
+      expect(roundTrip({ ':k:': 1 })).toEqual({ ':k:': 1 });
+    });
+
+    it('round-trips `{"a:b": 1}` (single colon in key)', () => {
+      expect(roundTrip({ 'a:b': 1 })).toEqual({ 'a:b': 1 });
+    });
+
+    it('round-trips a deeply-nested `::`-keyed object', () => {
+      const input = { outer: { '::': null } };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('still round-trips a real colon-delimited array (sanity)', () => {
+      // The encoder may pick COLON_DELIM for some arrays via the
+      // hash-based selector. Round-trip must still work for those.
+      const input = { items: ['a', 'b', 'c', 'd'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+});

--- a/src/__tests__/RoundTripFuzz.test.ts
+++ b/src/__tests__/RoundTripFuzz.test.ts
@@ -174,11 +174,12 @@ describe('Round-trip property tests (fast-check)', () => {
  *  4. Empty arrays in BRACKETS / JSON_STYLE / COLON_DELIM styles —
  *     only PIPES emits a recoverable empty-array form; the other
  *     three reduce to a key-only line that the lexer drops.
- *  5. Quoted-key + `<`-containing key + boolean value: the bracket
- *     regex is not quote-aware, splitting at the wrong `<`.
- *  6. Quoted-key + `:`-containing key in any KEY_VALUE form: the
- *     colon-array regex in `parseSpecialCases` is not quote-aware,
- *     causing `"::"=value` to be misread as a colon-delimited array.
+ *  5. (Resolved — bracket parsing in both `analyzeLineStructure`
+ *     and `parseSpecialCases` now uses `findSeparatorOutsideQuotes`
+ *     to find the structural `<` outside any quoted-key region.)
+ *  6. (Resolved — colon-array parsing in `parseSpecialCases` now
+ *     uses `findSeparatorOutsideQuotes` for the first `:` so a
+ *     quoted-key with `::` inside isn't misread as an array.)
  *  7. (Resolved — `selectSyntax` now requires `valueType === 'string'`
  *     before applying the semantic-category override; non-string
  *     values defer to the value-type branches.)
@@ -339,11 +340,7 @@ function hasKnownLimitation(input: unknown): boolean {
     // 75% of the time, all of which lose empty-array fidelity.
     if (Array.isArray(value) && value.length === 0) return true;
 
-    // (5) Quoted-key + `<`-in-key + boolean value.
-    if (key.includes('<') && typeof value === 'boolean') return true;
-
-    // (6) Quoted-key + `:`-in-key.
-    if (key.includes(':')) return true;
+    // (5) and (6) resolved; no constraints needed.
 
     // (7) and (8) resolved; no constraints needed.
 

--- a/src/__tests__/RoundTripFuzz.test.ts
+++ b/src/__tests__/RoundTripFuzz.test.ts
@@ -174,12 +174,15 @@ describe('Round-trip property tests (fast-check)', () => {
  *  4. Empty arrays in BRACKETS / JSON_STYLE / COLON_DELIM styles —
  *     only PIPES emits a recoverable empty-array form; the other
  *     three reduce to a key-only line that the lexer drops.
- *  5. (Resolved — bracket parsing in both `analyzeLineStructure`
- *     and `parseSpecialCases` now uses `findSeparatorOutsideQuotes`
- *     to find the structural `<` outside any quoted-key region.)
+ *  5. (Resolved — single-bracket parsing now lives only in
+ *     `analyzeLineStructure`'s fallback path, runs after the regular
+ *     separator scan, and uses `findSeparatorOutsideQuotes` for the
+ *     `<` so a quoted-key with `<` inside isn't misread.)
  *  6. (Resolved — colon-array parsing in `parseSpecialCases` now
- *     uses `findSeparatorOutsideQuotes` for the first `:` so a
- *     quoted-key with `::` inside isn't misread as an array.)
+ *     uses `findSeparatorOutsideQuotes` for the first `:` and
+ *     refuses to fire when an earlier KEY_VALUE separator outside
+ *     quotes appears before that `:`, so EQUALS-style strings like
+ *     `y=a:b:c` aren't misread as arrays.)
  *  7. (Resolved — `selectSyntax` now requires `valueType === 'string'`
  *     before applying the semantic-category override; non-string
  *     values defer to the value-type branches.)

--- a/src/lexer/RomlLexer.ts
+++ b/src/lexer/RomlLexer.ts
@@ -741,20 +741,36 @@ export class RomlLexer {
     // (legitimate quoted-key containing colons) isn't misread as a
     // colon-array. The "this is an array, not a scalar" disambiguator
     // is unchanged: the value-part must contain at least one more `:`.
+    //
+    // Additionally, only fire when no earlier KEY_VALUE separator
+    // (`=`, `~`, `#`, `%`, `$`, `^`, `+`) appears outside quotes
+    // before the first `:`. Otherwise an EQUALS-style string value
+    // like `y=a:b:c` would be misread as a 2-item colon-array.
     const firstColonPos = this.findSeparatorOutsideQuotes(line, ':');
     const colonRemainder = firstColonPos !== -1 ? line.slice(firstColonPos + 1) : '';
     if (firstColonPos !== -1 && colonRemainder.includes(':')) {
-      const k = extractKey(line.slice(0, firstColonPos));
-      const items = colonRemainder.split(':').map((item) => {
-        // Check if item is quoted (can be empty)
-        const quotedMatch = item.match(/^"(.*)"$/);
-        if (quotedMatch) {
-          // Preserve quoted values as strings and unescape
-          return unescapeStringValue(quotedMatch[1]);
+      const earlierSeparators = ['=', '~', '#', '%', '$', '^', '+'];
+      let hasEarlierSeparator = false;
+      for (const sep of earlierSeparators) {
+        const sepPos = this.findSeparatorOutsideQuotes(line, sep);
+        if (sepPos !== -1 && sepPos < firstColonPos) {
+          hasEarlierSeparator = true;
+          break;
         }
-        return this.parseSpecialValue(item);
-      });
-      return [k.key, items, 'COLON_DELIM', k.wasQuoted, k.hasPrimePrefix];
+      }
+      if (!hasEarlierSeparator) {
+        const k = extractKey(line.slice(0, firstColonPos));
+        const items = colonRemainder.split(':').map((item) => {
+          // Check if item is quoted (can be empty)
+          const quotedMatch = item.match(/^"(.*)"$/);
+          if (quotedMatch) {
+            // Preserve quoted values as strings and unescape
+            return unescapeStringValue(quotedMatch[1]);
+          }
+          return this.parseSpecialValue(item);
+        });
+        return [k.key, items, 'COLON_DELIM', k.wasQuoted, k.hasPrimePrefix];
+      }
     }
 
     return null;

--- a/src/lexer/RomlLexer.ts
+++ b/src/lexer/RomlLexer.ts
@@ -350,16 +350,6 @@ export class RomlLexer {
       }
     }
 
-    // Check for single bracket pattern: key<value>
-    const bracketMatch = line.match(/^(.+?)<(.+)>$/);
-    if (bracketMatch) {
-      return {
-        style: 'BRACKETS',
-        keyPart: bracketMatch[1],
-        valuePart: bracketMatch[2],
-      };
-    }
-
     // Define separator patterns in order of precedence
     const separators = [
       { char: '=', style: 'EQUALS' },
@@ -401,6 +391,26 @@ export class RomlLexer {
         keyPart: line.slice(0, earliestPos),
         valuePart: line.slice(earliestPos + 1),
       };
+    }
+
+    // Fallback to single bracket pattern: key<value>. Run after the
+    // separator scan so an EQUALS / COLON / etc. line wins when both
+    // shapes are present (e.g. `key=<value>` is EQUALS with value
+    // `<value>`, not BRACKETS with key `key=` and value `value`).
+    // Find the `<` outside any quoted region so a quoted-key like
+    // `"<"` doesn't get split at the wrong char. Require non-empty
+    // value content so `key<>` isn't claimed (that shape is the
+    // single-element array marker handled elsewhere).
+    if (line.endsWith('>')) {
+      const inner = line.slice(0, -1);
+      const bracketPos = this.findSeparatorOutsideQuotes(inner, '<');
+      if (bracketPos !== -1 && bracketPos < inner.length - 1) {
+        return {
+          style: 'BRACKETS',
+          keyPart: inner.slice(0, bracketPos),
+          valuePart: inner.slice(bracketPos + 1),
+        };
+      }
     }
 
     return null;
@@ -635,15 +645,11 @@ export class RomlLexer {
       return [k.key, items, 'BRACKETS', k.wasQuoted, k.hasPrimePrefix];
     }
 
-    // Parse single bracket style: key<value>
-    const bracketMatch = line.match(/^(.+?)<(.+)>$/);
-    if (bracketMatch) {
-      const k = extractKey(bracketMatch[1]);
-      const value = this.parseSpecialValue(bracketMatch[2]);
-      if (value === 'true') return [k.key, true, 'BRACKETS', k.wasQuoted, k.hasPrimePrefix];
-      if (value === 'false') return [k.key, false, 'BRACKETS', k.wasQuoted, k.hasPrimePrefix];
-      return [k.key, value, 'BRACKETS', k.wasQuoted, k.hasPrimePrefix];
-    }
+    // Single-bracket parsing has moved to `analyzeLineStructure`'s
+    // fallback so it runs after the regular separator scan — if a
+    // line has both an EQUALS/COLON/etc. separator and a `<...>`
+    // shape, the regular separator wins.
+
 
     // Parse pipe arrays: key||item1||item2|| (content between pipes can be empty)
     const pipeArrayMatch = line.match(/^(.+?)\|\|(.*)\|\|$/);
@@ -730,11 +736,16 @@ export class RomlLexer {
       return [k.key, items, 'JSON_STYLE', k.wasQuoted, k.hasPrimePrefix];
     }
 
-    // Parse colon-delimited arrays: key:item1:item2:item3
-    const colonArrayMatch = line.match(/^(.+?):(.+)$/);
-    if (colonArrayMatch && colonArrayMatch[2].includes(':')) {
-      const k = extractKey(colonArrayMatch[1]);
-      const items = colonArrayMatch[2].split(':').map((item) => {
+    // Parse colon-delimited arrays: key:item1:item2:item3. Find the
+    // first `:` outside any quoted region so a key like `"::"`
+    // (legitimate quoted-key containing colons) isn't misread as a
+    // colon-array. The "this is an array, not a scalar" disambiguator
+    // is unchanged: the value-part must contain at least one more `:`.
+    const firstColonPos = this.findSeparatorOutsideQuotes(line, ':');
+    const colonRemainder = firstColonPos !== -1 ? line.slice(firstColonPos + 1) : '';
+    if (firstColonPos !== -1 && colonRemainder.includes(':')) {
+      const k = extractKey(line.slice(0, firstColonPos));
+      const items = colonRemainder.split(':').map((item) => {
         // Check if item is quoted (can be empty)
         const quotedMatch = item.match(/^"(.*)"$/);
         if (quotedMatch) {


### PR DESCRIPTION
## Summary

Two related bugs in `RomlLexer`, both surfaced by the fast-check fuzz (#23) and constrained out by `hasKnownLimitation` until now.

**#5 — Bracket regex not quote-aware.** The single-bracket regex `^(.+?)<(.+)>$` (in both `analyzeLineStructure` and `parseSpecialCases`) wasn't quote-aware, so a quoted key containing `<` plus a value rendered as `"<"<value>` got split at the FIRST `<` (inside the quoted key) instead of the structural `<` separator:

```
{"<": false}  -> "<"<false>  -> {"\"": "\"<false"}   // wrong
```

**#6 — Colon-array regex not quote-aware.** The colon-array regex `^(.+?):(.+)$` in `parseSpecialCases` claimed any line with two `:`s as a colon-delimited array, even when the first `:` was inside a quoted key:

```
{"::": null}  -> "::"=__NULL__  -> {"\"": ["", "\"=__NULL__"]}   // wrong
```

Both fixed by replacing the regexes with `findSeparatorOutsideQuotes` (which already exists for AMPERSAND parsing) so the key/value split happens at the structural separator, not at one hidden inside a quoted key.

## Subtler precedence fix

A second issue surfaced while fixing #5: a line like `key=<value>` has both `=` and `<...>` shapes. The original regex backtracked and could end up claiming BRACKETS with key `key=` if the regex precedence happened to favour it; my first attempt preserved that brittle behaviour.

The cleaner solution is to move the single-bracket check to `analyzeLineStructure`'s **fallback path** so it runs AFTER the regular separator scan — if both shapes are present, the structural `=` / `:` / etc. wins. The redundant single-bracket handler in `parseSpecialCases` is removed; the multi-bracket handler (`<a><b>` arrays) stays since it's structurally distinct.

## BC break

No. Same valid ROML inputs round-trip the same way.

## Failing tests (added in this PR)

```ts
// src/__tests__/QuoteAwareRegexes.test.ts (11 tests)
describe('limitation #5: bracket regex quote-awareness', () => {
  it('round-trips `{"<": false}` (single < in key with boolean)', ...);
  it('round-trips `{">": true}` (single > in key with boolean)', ...);
  it('round-trips `{"<key>": true}` (key with surrounding angle brackets)', ...);
  it('round-trips a key containing < at multiple positions with a boolean value', ...);
  it('still round-trips an ordinary boolean (sanity)', ...);
});
describe('limitation #6: colon-array regex quote-awareness', () => {
  it('round-trips `{"::": null}` (key is two colons)', ...);
  it('round-trips `{"::": "value"}` (string value)', ...);
  it('round-trips `{":k:": 1}` (colons surrounding the key)', ...);
  it('round-trips `{"a:b": 1}` (single colon in key)', ...);
  it('round-trips a deeply-nested `::`-keyed object', ...);
  it('still round-trips a real colon-delimited array (sanity)', ...);
});
```

Before fix: 5 of 11 fail. After fix: 11 of 11 pass.

## Files touched

- `src/lexer/RomlLexer.ts` — `analyzeLineStructure` bracket fallback rewritten with `findSeparatorOutsideQuotes`; `parseSpecialCases` colon-array rewritten the same way; redundant single-bracket handler in `parseSpecialCases` removed.
- `src/__tests__/QuoteAwareRegexes.test.ts` — regression coverage.
- `src/__tests__/RoundTripFuzz.test.ts` — drop limitations #5 and #6 from `hasKnownLimitation`; mark resolved in the docstring counter.

## Test plan

- [x] `npm install && npm run build && npm run lint && npm test` — 369 tests pass (was 358 + 11 new), lint and build clean.
- [x] Fuzz still passes with both constraints removed (pinned seed `20260507`, 100 runs per property).
- [x] Smoke: `node -e 'import("./dist/file/RomlFile.js").then(m=>console.log(JSON.stringify(m.RomlFile.romlToJson(m.RomlFile.jsonToRoml({"<":false,"::":null})))))'` returns `{"<":false,"::":null}` rather than the previously-mangled key/value.

Of the original 15 fuzz limitations, this PR resolves #5 and #6 (after PR #24 resolved #2 and PR #25 resolved #7+#8). Remaining smaller candidates: #10 (empty-quoted-value regex). The architectural ones (#1 wrapper collision, #3 single-element array ambiguity) and the per-style item escaping (#9, #11, #14) are larger.

https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV)_