### PR TITLE
fix(lexer): recognise the empty quoted value `""` (limitation #10)

### DIFF
--- a/src/__tests__/EmptyQuotedValue.test.ts
+++ b/src/__tests__/EmptyQuotedValue.test.ts
@@ -13,7 +13,7 @@ describe('Empty quoted-value regex (limitation #10)', () => {
   // so the round-trip path through the encoder doesn't trigger this.
   // But the lexer must still parse hand-written ROML correctly —
   // and it currently doesn't for `::key::""::`, `@key@""@`,
-  // `_key_""_`, the multi-bracket array item `<""\>`, and the
+  // `_key_""_`, the multi-bracket array item `<"">`, and the
   // pipe-array per-item / single-value forms.
   //
   // Fix: change `^"(.+)"$` to `^"(.*)"$` in all five remaining
@@ -51,6 +51,16 @@ describe('Empty quoted-value regex (limitation #10)', () => {
       // empty string (or, for synthetic wrapper keys, an empty
       // string in a 1-element array).
       expect(RomlFile.romlToJson('~ROML~\nx||""||')).toEqual({ x: '' });
+    });
+
+    it('parses DOUBLE_COLON with `::` inside a quoted key', () => {
+      // Surfaced by Copilot review on PR #28: the DOUBLE_COLON
+      // branch used `content.indexOf('::')` which split a quoted
+      // key containing `::` at the inner `::`. Now scan for the
+      // structural `::` outside quotes.
+      expect(RomlFile.romlToJson('~ROML~\n::"a::b"::"x"::')).toEqual({
+        'a::b': 'x',
+      });
     });
   });
 

--- a/src/__tests__/EmptyQuotedValue.test.ts
+++ b/src/__tests__/EmptyQuotedValue.test.ts
@@ -1,0 +1,70 @@
+import { RomlFile } from '../file/RomlFile';
+
+describe('Empty quoted-value regex (limitation #10)', () => {
+  // Regression: `parseSpecialCases` and the inline-array branches
+  // used `^"(.+)"$` to detect quoted values. The `(.+)` requires at
+  // least one char inside the quotes, so the empty quoted form
+  // `""` doesn't match and gets parsed as the literal 2-char value
+  // `""` instead of the empty string.
+  //
+  // After PR #25 the encoder no longer reaches the affected branches
+  // for empty-string values (special-value override routes them
+  // through FAKE_COMMENT / DOLLAR, both of which already used `*`),
+  // so the round-trip path through the encoder doesn't trigger this.
+  // But the lexer must still parse hand-written ROML correctly —
+  // and it currently doesn't for `::key::""::`, `@key@""@`,
+  // `_key_""_`, the multi-bracket array item `<""\>`, and the
+  // pipe-array per-item / single-value forms.
+  //
+  // Fix: change `^"(.+)"$` to `^"(.*)"$` in all five remaining
+  // sites so the empty case parses as an empty string.
+
+  describe('hand-written ROML decoding', () => {
+    it('parses DOUBLE_COLON empty-quoted-value as empty string', () => {
+      expect(RomlFile.romlToJson('~ROML~\n::k::""::')).toEqual({ k: '' });
+    });
+
+    it('parses AT_SANDWICH empty-quoted-value as empty string', () => {
+      expect(RomlFile.romlToJson('~ROML~\n@k@""@')).toEqual({ k: '' });
+    });
+
+    it('parses UNDERSCORE empty-quoted-value as empty string', () => {
+      expect(RomlFile.romlToJson('~ROML~\n_k_""_')).toEqual({ k: '' });
+    });
+
+    it('parses multi-bracket array with an empty quoted item', () => {
+      // multiBracketMatch fires when `line.includes('><')`, so we
+      // need at least two brackets. Empty `""` should decode to ''.
+      expect(RomlFile.romlToJson('~ROML~\nxs<a><""><b>')).toEqual({
+        xs: ['a', '', 'b'],
+      });
+    });
+
+    it('parses pipe-array with an empty quoted item', () => {
+      expect(RomlFile.romlToJson('~ROML~\nxs||a||""||b||')).toEqual({
+        xs: ['a', '', 'b'],
+      });
+    });
+
+    it('parses single-value pipe-array form with empty quoted value', () => {
+      // Single-value pipe form: `key||""||`. Should decode to the
+      // empty string (or, for synthetic wrapper keys, an empty
+      // string in a 1-element array).
+      expect(RomlFile.romlToJson('~ROML~\nx||""||')).toEqual({ x: '' });
+    });
+  });
+
+  describe('encoder round-trip (sanity, was already working post-PR#25)', () => {
+    function roundTrip(input: unknown): unknown {
+      return RomlFile.romlToJson(RomlFile.jsonToRoml(input));
+    }
+
+    it('round-trips an empty-string value under a TEMPORAL key', () => {
+      expect(roundTrip({ created: '' })).toEqual({ created: '' });
+    });
+
+    it('round-trips an empty-string value under an ordinary key', () => {
+      expect(roundTrip({ x: '' })).toEqual({ x: '' });
+    });
+  });
+});

--- a/src/__tests__/RoundTripFuzz.test.ts
+++ b/src/__tests__/RoundTripFuzz.test.ts
@@ -194,11 +194,10 @@ describe('Round-trip property tests (fast-check)', () => {
  *     items, so the lexer's `<([^>]*)>` regex splits at the wrong
  *     `>`. We don't know which array style the encoder will pick (it
  *     hashes the key), so any string-array containing `>` is skipped.
- * 10. Empty-string value with a semantic-category key (`created` →
- *     AT_SANDWICH and similar): `parseSpecialCases` uses
- *     `^"(.+)"$` to detect quoted values, which doesn't match the
- *     empty `""`. The string gets parsed as the literal 2-char
- *     value `""`.
+ * 10. (Resolved — the value-quoted regex sites in
+ *     `parseSpecialCases` and the inline-array branches now use
+ *     `^"(.*)"$` so the empty `""` is recognised as an empty
+ *     string rather than parsed as the literal 2-char value.)
  * 11. JSON_STYLE primitive array containing a string with `"`: the
  *     encoder uses `JSON.stringify` (which escapes the quote as
  *     `\"`) but the parser slices off the outer quotes without
@@ -231,50 +230,6 @@ const COLLECTION_KEYS = new Set([
   'elements',
   'values',
   'data',
-]);
-
-const SEMANTIC_KEYS = new Set([
-  'name',
-  'first_name',
-  'last_name',
-  'email',
-  'phone',
-  'address',
-  'username',
-  'active',
-  'enabled',
-  'valid',
-  'working',
-  'online',
-  'disabled',
-  'inactive',
-  'tags',
-  'items',
-  'list',
-  'array',
-  'elements',
-  'values',
-  'data',
-  'id',
-  'uuid',
-  'hash',
-  'checksum',
-  'token',
-  'key',
-  'secret',
-  'salary',
-  'price',
-  'cost',
-  'amount',
-  'total',
-  'balance',
-  'fee',
-  'date',
-  'time',
-  'created',
-  'updated',
-  'timestamp',
-  'expires',
 ]);
 
 /**
@@ -355,8 +310,7 @@ function hasKnownLimitation(input: unknown): boolean {
       return true;
     }
 
-    // (10) Empty-string value with a semantic-category key.
-    if (value === '' && SEMANTIC_KEYS.has(key.toLowerCase())) return true;
+    // (10) resolved; no constraint needed.
 
     // (11) Array containing a string with `"` or `\` (JSON_STYLE
     //      escape mismatch — encoder uses JSON.stringify but the

--- a/src/lexer/RomlLexer.ts
+++ b/src/lexer/RomlLexer.ts
@@ -511,8 +511,34 @@ export class RomlLexer {
     // Parse double colon style: ::key::value::
     if (line.startsWith('::') && line.endsWith('::')) {
       const content = line.slice(2, -2);
-      // Find the :: separator within the content
-      const separatorIndex = content.indexOf('::');
+      // Find the structural `::` separator OUTSIDE any quoted
+      // region — `content.indexOf('::')` would split a quoted key
+      // like `"a::b"` at the inner `::` (limitation #6 family
+      // surfaced by Copilot review on PR #28).
+      let separatorIndex = -1;
+      {
+        let inQuotes = false;
+        let escapeNext = false;
+        for (let i = 0; i < content.length - 1; i++) {
+          const ch = content[i];
+          if (escapeNext) {
+            escapeNext = false;
+            continue;
+          }
+          if (ch === '\\') {
+            escapeNext = true;
+            continue;
+          }
+          if (ch === '"') {
+            inQuotes = !inQuotes;
+            continue;
+          }
+          if (!inQuotes && ch === ':' && content[i + 1] === ':') {
+            separatorIndex = i;
+            break;
+          }
+        }
+      }
       if (separatorIndex !== -1) {
         const keyPart = content.slice(0, separatorIndex);
         const valuePart = content.slice(separatorIndex + 2); // +2 to skip both colons

--- a/src/lexer/RomlLexer.ts
+++ b/src/lexer/RomlLexer.ts
@@ -518,8 +518,10 @@ export class RomlLexer {
         const valuePart = content.slice(separatorIndex + 2); // +2 to skip both colons
         const k = extractKey(keyPart);
 
-        // Check if value is quoted
-        const quotedValueMatch = valuePart.match(/^"(.+)"$/);
+        // Check if value is quoted. `(.*)` not `(.+)` so the empty
+        // quoted form `""` is recognised as an empty string rather
+        // than parsed as the literal 2-char value `""`.
+        const quotedValueMatch = valuePart.match(/^"(.*)"$/);
         if (quotedValueMatch) {
           return [
             k.key,
@@ -577,7 +579,8 @@ export class RomlLexer {
         const valuePart = content.slice(separatorPos + 1);
         const k = extractKey(keyPart);
 
-        const quotedValueMatch = valuePart.match(/^"(.+)"$/);
+        // `(.*)` so the empty quoted form `""` is recognised.
+        const quotedValueMatch = valuePart.match(/^"(.*)"$/);
         if (quotedValueMatch) {
           return [
             k.key,
@@ -606,7 +609,8 @@ export class RomlLexer {
         const valuePart = content.slice(separatorPos + 1);
         const k = extractKey(keyPart);
 
-        const quotedValueMatch = valuePart.match(/^"(.+)"$/);
+        // `(.*)` so the empty quoted form `""` is recognised.
+        const quotedValueMatch = valuePart.match(/^"(.*)"$/);
         if (quotedValueMatch) {
           return [
             k.key,
@@ -634,8 +638,9 @@ export class RomlLexer {
         .map((match) => match[1])
         .filter((itemValue) => itemValue !== '') // Filter out empty brackets
         .map((itemValue) => {
-          // Check if item is quoted
-          const quotedMatch = itemValue.match(/^"(.+)"$/);
+          // Check if item is quoted. `(.*)` so the empty quoted
+          // form `""` is recognised as an empty string.
+          const quotedMatch = itemValue.match(/^"(.*)"$/);
           if (quotedMatch) {
             // Preserve quoted values as strings and unescape
             return unescapeStringValue(quotedMatch[1]);
@@ -661,8 +666,8 @@ export class RomlLexer {
           .split('||')
           .filter((item) => item.trim())
           .map((item) => {
-            // Check if item is quoted
-            const quotedMatch = item.match(/^"(.+)"$/);
+            // Check if item is quoted. `(.*)` so `""` parses as ''.
+            const quotedMatch = item.match(/^"(.*)"$/);
             if (quotedMatch) {
               // Preserve quoted values as strings and unescape
               return unescapeStringValue(quotedMatch[1]);
@@ -676,8 +681,9 @@ export class RomlLexer {
           return [k.key, [], 'PIPES', k.wasQuoted, k.hasPrimePrefix];
         }
 
-        // Check if single value is quoted
-        const quotedMatch = value.match(/^"(.+)"$/);
+        // Check if single value is quoted. `(.*)` so `""` parses
+        // as the empty string rather than the literal 2-char `""`.
+        const quotedMatch = value.match(/^"(.*)"$/);
         const singleValue = quotedMatch
           ? unescapeStringValue(quotedMatch[1])
           : this.parseSpecialValue(value);


### PR DESCRIPTION
## Summary

Five remaining `^"(.+)"$` value-side / item-side regex sites in `RomlLexer` required at least one char inside the quotes, so the empty quoted form `""` didn't match. The value got parsed as the literal 2-char string `""` instead of the empty string.

**Affected sites:**
- `parseSpecialCases` DOUBLE_COLON value match
- `parseSpecialCases` AT_SANDWICH value match
- `parseSpecialCases` UNDERSCORE value match
- multi-bracket per-item match
- pipe-array per-item match (multi-element form)
- pipe-array single-value match

(FAKE_COMMENT and DOLLAR already used `(.*)` and worked correctly.)

After PR #25 the encoder no longer reaches the affected sites for empty-string values via the round-trip path — the special-value override routes empty strings through FAKE_COMMENT / DOLLAR — so this didn't surface in encoder round-trip fuzzing. But the lexer must still parse hand-written ROML correctly for these forms, and it didn't:

```
~ROML~
@k@""@           ->  {k: '""'}    // wrong, should be {k: ''}
::k::""::        ->  {k: '""'}    // wrong
_k_""_           ->  {k: '""'}    // wrong
xs<a><""><b>     ->  {xs: ['a', '""', 'b']}    // wrong
xs||a||""||b||   ->  {xs: ['a', '""', 'b']}    // wrong
x||""||          ->  {x: '""'}    // wrong
```

Fix: change all five remaining `^"(.+)"$` sites to `^"(.*)"$`. Defense-in-depth — the encoder doesn't currently produce these shapes for empty values, but the lexer should parse them correctly if someone hand-writes them.

## BC break

No.

## Failing tests (added in this PR)

```ts
// src/__tests__/EmptyQuotedValue.test.ts (8 tests)
describe('hand-written ROML decoding', () => {
  it('parses DOUBLE_COLON empty-quoted-value as empty string', ...);
  it('parses AT_SANDWICH empty-quoted-value as empty string', ...);
  it('parses UNDERSCORE empty-quoted-value as empty string', ...);
  it('parses multi-bracket array with an empty quoted item', ...);
  it('parses pipe-array with an empty quoted item', ...);
  it('parses single-value pipe-array form with empty quoted value', ...);
});
describe('encoder round-trip (sanity, was already working post-PR#25)', () => {
  it('round-trips an empty-string value under a TEMPORAL key', ...);
  it('round-trips an empty-string value under an ordinary key', ...);
});
```

Before fix: 6 of 8 fail (the two encoder-round-trip tests pass — encoder routes around the broken sites). After fix: 8 of 8 pass.

## Files touched

- `src/lexer/RomlLexer.ts` — five regex sites updated.
- `src/__tests__/EmptyQuotedValue.test.ts` — regression coverage via direct lexer / decoder testing.
- `src/__tests__/RoundTripFuzz.test.ts` — drop limitation #10 from `hasKnownLimitation`; mark resolved in the docstring counter; delete the now-unused `SEMANTIC_KEYS` constant.

## Test plan

- [x] `npm install && npm run build && npm run lint && npm test` — 379 tests pass (was 371 + 8 new), lint and build clean.
- [x] Fuzz still passes with limitation #10 removed (pinned seed `20260507`, 100 runs per property).
- [x] Smoke: `node -e 'import("./dist/file/RomlFile.js").then(m=>console.log(JSON.stringify(m.RomlFile.romlToJson("~ROML~\n@k@\"\"@"))))'` returns `{"k":""}` rather than `{"k":"\"\""}`.

Of the original 15 fuzz limitations, this PR resolves #10 (after #2 / #5+#6 / #7+#8 in earlier PRs). Remaining: #1 (synthetic-wrapper), #3 (single-element array), #4 (empty arrays in non-PIPES), #9 (BRACKETS `>`), #11 (JSON_STYLE `"`/`\`), #12 (PIPES KV `|`), #13 (COLLECTIONS PIPES KV vs array), #14 (per-style item separators), #15 (underscore-bounded line collision). The smaller remaining ones are #4 and #15; #1 and #3 are architectural; #9 + #11 + #14 are the per-style item-escaping family.

https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV)_