### PR TITLE
test: import SEMANTIC_CATEGORIES into the fuzz arbitrary

### DIFF
--- a/src/RomlConverter.ts
+++ b/src/RomlConverter.ts
@@ -118,7 +118,7 @@ interface ConversionContext {
   readonly documentFeatures: DocumentFeatures;
 }
 
-const SEMANTIC_CATEGORIES = {
+export const SEMANTIC_CATEGORIES = {
   PERSONAL: ['name', 'first_name', 'last_name', 'email', 'phone', 'address', 'username'] as const,
   STATUS: ['active', 'enabled', 'valid', 'working', 'online', 'disabled', 'inactive'] as const,
   COLLECTIONS: ['tags', 'items', 'list', 'array', 'elements', 'values', 'data'] as const,

--- a/src/__tests__/RoundTripFuzz.test.ts
+++ b/src/__tests__/RoundTripFuzz.test.ts
@@ -1,5 +1,14 @@
 import * as fc from 'fast-check';
 import { RomlFile } from '../file/RomlFile';
+import { SEMANTIC_CATEGORIES } from '../RomlConverter';
+
+/**
+ * The full set of semantic-category keywords (every entry across
+ * every category in `SEMANTIC_CATEGORIES`). Imported from the
+ * canonical source rather than duplicated here so the fuzz arbitrary
+ * automatically widens whenever the taxonomy grows. See issue #29.
+ */
+const SEMANTIC_KEYWORDS: readonly string[] = Object.values(SEMANTIC_CATEGORIES).flat();
 
 /**
  * Property-based round-trip coverage.
@@ -80,12 +89,7 @@ const stressKey = fc.oneof(
     '__EMPTY__',
     '__UNDEFINED__',
     '!warn',
-    'name',
-    'salary',
-    'created',
-    'tags',
-    'id',
-    'active'
+    ...SEMANTIC_KEYWORDS
   )
 );
 


### PR DESCRIPTION
Closes #29.

## Summary

Until now the property-based fuzz's `stressKey` arbitrary hand-listed six representatives drawn from the 41 semantic-category keywords:

```
'name', 'salary', 'created', 'tags', 'id', 'active'
```

The remaining 35 keywords (`first_name`, `last_name`, `email`, `phone`, `address`, `username`, `enabled`, `valid`, `working`, `online`, `disabled`, `inactive`, `items`, `list`, `array`, `elements`, `values`, `data`, `uuid`, `hash`, `checksum`, `token`, `key`, `secret`, `price`, `cost`, `amount`, `total`, `balance`, `fee`, `date`, `time`, `updated`, `timestamp`, `expires`) were not directly exercised by the fuzz, leaving ~85% of the canonical taxonomy in an unexamined penumbra.

## Two coordinated changes

**1. Export `SEMANTIC_CATEGORIES` from `src/RomlConverter.ts`.**

The shape (`as const`, six readonly tuples of readonly string literals) was already correct; only the `export` keyword was missing.

**2. Import the canonical taxonomy in `src/__tests__/RoundTripFuzz.test.ts`** and rebuild the semantic-keyword half of `stressKey` so it derives from the imported source:

```ts
import { SEMANTIC_CATEGORIES } from '../RomlConverter';

const SEMANTIC_KEYWORDS: readonly string[] = Object.values(SEMANTIC_CATEGORIES).flat();

const stressKey = fc.oneof(
  stressString,
  fc.constantFrom(
    '__NULL__',
    '__EMPTY__',
    '__UNDEFINED__',
    '!warn',
    ...SEMANTIC_KEYWORDS
  )
);
```

Future expansion of the taxonomy (adding a new keyword to PERSONAL, say) will then automatically widen fuzz coverage without a corresponding test edit. One source, one truth.

## BC break

No. Additive `export` keyword plus a test-internal change.

## Test plan

- [x] `npm install && npm run build && npm run lint && npm test` clean. 380 tests pass (no count change; the broader stressKey doesn't add tests, it broadens existing ones).
- [x] Targeted: `npx jest src/__tests__/RoundTripFuzz.test.ts` passes deterministically across multiple runs under the pinned seed (`20260507`, 100 runs per property).
- [x] Hygiene: `git grep -n SEMANTIC_KEYS src/__tests__/` returns no hits; the duplicated string literal that previously lived in the test file (removed in #28) does not creep back.

The categorical imperative endures.

https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV)_