### PR TITLE
fix(format): META-tag disambiguation for synthetic root wrappers (#1 + #15)

### DIFF
--- a/src/RomlConverter.ts
+++ b/src/RomlConverter.ts
@@ -171,15 +171,23 @@ export class RomlConverter {
     // pipeline to handle the embedded quotes correctly.
     if (value.startsWith('"') || value.endsWith('"')) return true;
 
-    // Check if string ends with `{` or `[` (after trimming trailing
-    // whitespace). The lexer trims every line before matching the
-    // OBJECT_START / ARRAY_START regexes, so a value like `'open { '`
-    // would still be mis-tokenized as `OBJECT_START` after lexer
-    // trimming even though the raw value doesn't end with `{`. Use
-    // `trimEnd()` so values with trailing whitespace before the
-    // structural char are also routed through `QUOTED`.
+    // Check if string ends with a structural character that could
+    // confuse the lexer (after trimming trailing whitespace, since
+    // the lexer trims every line before matching). `{` and `[` look
+    // like OBJECT_START / ARRAY_START openers; `]` and `}` are the
+    // closing counterparts that interact with `jsonArrayMatch` and
+    // OBJECT_END / ARRAY_END detection. Routing any of them through
+    // `QUOTED` lets the existing escape pipeline carry the value
+    // safely.
     const trimmedEnd = value.trimEnd();
-    if (trimmedEnd.endsWith('{') || trimmedEnd.endsWith('[')) return true;
+    if (
+      trimmedEnd.endsWith('{') ||
+      trimmedEnd.endsWith('[') ||
+      trimmedEnd.endsWith(']') ||
+      trimmedEnd.endsWith('}')
+    ) {
+      return true;
+    }
 
     // Check if string contains newlines (would break single-line format)
     if (value.includes('\n') || value.includes('\r')) return true;
@@ -268,10 +276,22 @@ export class RomlConverter {
       processData = data as Record<string, unknown>;
     }
 
-    const documentFeatures = this.analyzeDocumentFeatures(processData);
+    const documentFeatures = this.analyzeDocumentFeatures(processData, inputType);
 
     // Build header components
     const headerLines = ['~ROML~'];
+
+    // Root-wrapping META tags. Emitted only when the encoder
+    // synthetically wrapped a non-object root; the parser uses these
+    // to license the unwrap, so a user document that happens to use
+    // the wrapper sentinel as a real key (and so emits no META) is
+    // round-tripped as an object instead of being silently
+    // unwrapped.
+    if (inputType === 'array') {
+      headerLines.push(`# ~META~ ${MetaTags.ROOT_ARRAY}`);
+    } else if (inputType === 'primitive') {
+      headerLines.push(`# ~META~ ${MetaTags.ROOT_PRIMITIVE}`);
+    }
 
     // Simplified prime META tag logic - always generate for objects with primes
     if (documentFeatures.primesDetected) {
@@ -735,10 +755,26 @@ export class RomlConverter {
   /**
    * Analyze document-level features
    */
-  private analyzeDocumentFeatures(data: Record<string, unknown>): DocumentFeatures {
+  private analyzeDocumentFeatures(
+    data: Record<string, unknown>,
+    inputType: JsonType = 'object'
+  ): DocumentFeatures {
+    // Only apply the wrapper-key short-circuit when the encoder is
+    // actually performing a synthetic wrap. For object roots that
+    // happen to contain a `__roml_items__` / `__roml_value__` key,
+    // the wrapper-key shape is a coincidence and prime detection
+    // must walk through normally.
+    const primesDetected =
+      inputType === 'object'
+        ? objectContainsPrimes(data)
+        : this.objectContainsPrimesExcludingWrapperKeys(data);
     return {
-      primesDetected: this.objectContainsPrimesExcludingWrapperKeys(data),
-      rootType: 'object', // Always object in wrapper approach
+      primesDetected,
+      // Track the actual root type (not always 'object') so
+      // line-level features can distinguish a genuine synthetic
+      // wrap from a user object that happens to use the wrapper
+      // sentinel as a key.
+      rootType: inputType,
     };
   }
 
@@ -812,8 +848,17 @@ export class RomlConverter {
     const needsQuotes =
       typeof value === 'string' && this.isAmbiguousString(value) && !(value === '' && isArrayItem);
 
+    // Suppress the prime-prefix on a wrapper-shaped key only when
+    // the encoder is in synthetic-wrap mode AND we're at the root
+    // of the document (depth 0). User objects that happen to use a
+    // wrapper sentinel as a key, or any nested use of the same
+    // shape, must not be short-circuited.
+    const isSyntheticWrapAtRoot =
+      this.isSyntheticWrapperKey(key) &&
+      nestingDepth === 0 &&
+      context?.documentFeatures.rootType !== 'object';
     return {
-      containsPrime: this.isSyntheticWrapperKey(key) ? false : containsPrime(value),
+      containsPrime: isSyntheticWrapAtRoot ? false : containsPrime(value),
       hasLargeArray,
       isNestedObject,
       keyStartsWithVowel,

--- a/src/__tests__/RootMetaTag.test.ts
+++ b/src/__tests__/RootMetaTag.test.ts
@@ -1,0 +1,125 @@
+import { RomlFile } from '../file/RomlFile';
+
+describe('Root-wrapper META-tag disambiguation', () => {
+  // Regression for fuzz limitation #1.
+  //
+  // The encoder wraps top-level non-object roots as
+  // `{__roml_items__: [...]}` (for arrays) or `{__roml_value__: x}`
+  // (for primitives) so the rest of the encoder can assume an
+  // object root. The parser used to unconditionally unwrap any
+  // single-key object whose key matched a wrapper sentinel, which
+  // meant a user document of that exact shape was structurally
+  // indistinguishable from an encoder-wrapped non-object root and
+  // got silently collapsed on round-trip:
+  //
+  //   {"__roml_items__":[1,2,3]}  -> ROML -> [1,2,3]   (data lost)
+  //
+  // Fix: the encoder now emits a META tag in the document header
+  // (`# ~META~ ROOT_ARRAY` or `# ~META~ ROOT_PRIMITIVE`) whenever it
+  // synthetically wraps. The parser only unwraps when the matching
+  // META tag is present. A user document with the wrapper sentinel
+  // as a key produces no META tag and so round-trips intact.
+
+  function roundTrip(input: unknown): unknown {
+    return RomlFile.romlToJson(RomlFile.jsonToRoml(input));
+  }
+
+  describe('encoder emits the META tag for synthetic wraps', () => {
+    it('emits ROOT_ARRAY when the input is a top-level array', () => {
+      const roml = RomlFile.jsonToRoml([1, 2, 3]);
+      expect(roml).toContain('# ~META~ ROOT_ARRAY');
+    });
+
+    it('emits ROOT_PRIMITIVE when the input is a top-level primitive', () => {
+      expect(RomlFile.jsonToRoml(42)).toContain('# ~META~ ROOT_PRIMITIVE');
+      expect(RomlFile.jsonToRoml('hi')).toContain('# ~META~ ROOT_PRIMITIVE');
+      expect(RomlFile.jsonToRoml(true)).toContain('# ~META~ ROOT_PRIMITIVE');
+      expect(RomlFile.jsonToRoml(null)).toContain('# ~META~ ROOT_PRIMITIVE');
+    });
+
+    it('does NOT emit a root-wrapper META for object roots', () => {
+      const roml = RomlFile.jsonToRoml({ a: 1 });
+      expect(roml).not.toContain('# ~META~ ROOT_ARRAY');
+      expect(roml).not.toContain('# ~META~ ROOT_PRIMITIVE');
+    });
+
+    it('does NOT emit a root-wrapper META for objects whose key happens to be the sentinel', () => {
+      // Critical for limitation #1: a user object with the wrapper
+      // key gets no META, so the parser does not unwrap it.
+      const a = RomlFile.jsonToRoml({ __roml_items__: [1, 2, 3] });
+      const b = RomlFile.jsonToRoml({ __roml_value__: 42 });
+      expect(a).not.toContain('# ~META~ ROOT_ARRAY');
+      expect(b).not.toContain('# ~META~ ROOT_PRIMITIVE');
+    });
+  });
+
+  describe('round-trip for genuine non-object roots', () => {
+    it('top-level array round-trips via the META + wrap', () => {
+      expect(roundTrip([1, 2, 3])).toEqual([1, 2, 3]);
+    });
+
+    it('top-level primitives round-trip via the META + wrap', () => {
+      expect(roundTrip(42)).toEqual(42);
+      expect(roundTrip('hello')).toEqual('hello');
+      expect(roundTrip(true)).toEqual(true);
+      expect(roundTrip(false)).toEqual(false);
+      expect(roundTrip(null)).toEqual(null);
+    });
+
+    it('nested arrays of objects round-trip', () => {
+      expect(roundTrip([{ a: 1 }, { b: 2 }])).toEqual([{ a: 1 }, { b: 2 }]);
+    });
+  });
+
+  describe('user objects with wrapper-key shapes round-trip intact', () => {
+    it('round-trips `{"__roml_items__": [...]}` as an object, not an array', () => {
+      const input = { __roml_items__: [1, 2, 3] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips `{"__roml_value__": x}` as an object, not the inner value', () => {
+      expect(roundTrip({ __roml_value__: 42 })).toEqual({ __roml_value__: 42 });
+      expect(roundTrip({ __roml_value__: 'x' })).toEqual({ __roml_value__: 'x' });
+      expect(roundTrip({ __roml_value__: null })).toEqual({ __roml_value__: null });
+    });
+
+    it('round-trips an object containing both wrapper sentinels as keys', () => {
+      const input = { __roml_items__: 'a', __roml_value__: 'b' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips a wrapper-shape object inside a deeper structure', () => {
+      const input = { outer: { __roml_items__: [1, 2, 3] } };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+
+  describe('hand-written ROML decoding', () => {
+    it('without ROOT_ARRAY META, a `__roml_items__` single-key shape decodes as an object', () => {
+      const roml = '~ROML~\n__roml_items__||1||2||3||';
+      expect(RomlFile.romlToJson(roml)).toEqual({ __roml_items__: [1, 2, 3] });
+    });
+
+    it('with ROOT_ARRAY META, the same payload decodes as the unwrapped array', () => {
+      const roml = '~ROML~\n# ~META~ ROOT_ARRAY\n__roml_items__||1||2||3||';
+      expect(RomlFile.romlToJson(roml)).toEqual([1, 2, 3]);
+    });
+
+    it('with ROOT_PRIMITIVE META, a `__roml_value__` payload decodes as the unwrapped primitive', () => {
+      // Note: counter advances past two header lines, so the data
+      // line lands on counter=2 (even). For a string value `hi`
+      // (consonant key, short string) the encoder's hash-fallback
+      // picks an EQUALS family style; here we just check that the
+      // META + payload combination yields the inner primitive.
+      expect(
+        RomlFile.romlToJson('~ROML~\n# ~META~ ROOT_PRIMITIVE\n__roml_value__="hi"')
+      ).toEqual('hi');
+    });
+
+    it('declaring both ROOT_ARRAY and ROOT_PRIMITIVE is a parse error', () => {
+      const roml =
+        '~ROML~\n# ~META~ ROOT_ARRAY\n# ~META~ ROOT_PRIMITIVE\n__roml_items__||1||';
+      expect(() => RomlFile.romlToJson(roml)).toThrow(/only one root-wrapper tag/i);
+    });
+  });
+});

--- a/src/__tests__/RoundTripFuzz.test.ts
+++ b/src/__tests__/RoundTripFuzz.test.ts
@@ -74,13 +74,12 @@ const stressString = fc
  * Object-key arbitrary that mixes generic stress strings with a hand-
  * picked set of known ROML-trouble names.
  *
- * `__roml_items__` / `__roml_value__` are EXCLUDED on purpose: they
- * are the encoder's synthetic wrapper sentinels for top-level
- * non-object roots. A user object whose only top-level key is one of
- * those names with the matching wrapper-shape value (`{__roml_items__: [...]}`
- * or `{__roml_value__: x}`) is structurally indistinguishable from a
- * synthetically-wrapped primitive after parsing — that's a known
- * architectural collision tracked separately.
+ * Note: `__roml_items__` / `__roml_value__` are the encoder's
+ * synthetic wrapper sentinels for top-level non-object roots. After
+ * the META-tag disambiguation fix in PR #29, a user object that
+ * happens to use these as keys round-trips correctly because the
+ * encoder only emits the unwrap-licensing META tag when actually
+ * synthesising the wrap.
  */
 const stressKey = fc.oneof(
   stressString,
@@ -89,6 +88,11 @@ const stressKey = fc.oneof(
     '__EMPTY__',
     '__UNDEFINED__',
     '!warn',
+    // Synthetic-wrapper sentinels are now legitimate user keys
+    // (PR #29 added META-tag disambiguation), so include them in
+    // the stress arbitrary to exercise the wrapper-collision case.
+    '__roml_items__',
+    '__roml_value__',
     ...SEMANTIC_KEYWORDS
   )
 );
@@ -165,10 +169,11 @@ describe('Round-trip property tests (fast-check)', () => {
  * inside an otherwise-fine document is also skipped.
  *
  * Known limitations (each is a follow-up PR candidate):
- *  1. Synthetic-wrapper collision: a single-key object whose key is
- *     `__roml_items__` (array value) or `__roml_value__` (any value)
- *     is structurally indistinguishable from a wrap of a non-object
- *     root after parsing.
+ *  1. (Resolved — encoder emits `# ~META~ ROOT_ARRAY` /
+ *     `# ~META~ ROOT_PRIMITIVE` for synthetic wraps; parser only
+ *     unwraps when the matching META tag is present, so user
+ *     objects that use the wrapper sentinel as a key round-trip
+ *     intact.)
  *  2. (Resolved — `needsQuotedKey` now flags `\`-containing keys so
  *     the encoder routes them through QUOTED. Number kept for
  *     stable cross-referencing in this docstring.)
@@ -277,13 +282,8 @@ function hasKnownLimitation(input: unknown): boolean {
   }
 
   const obj = input as Record<string, unknown>;
-  const keys = Object.keys(obj);
 
-  // (1) Synthetic-wrapper collision.
-  if (keys.length === 1) {
-    if (keys[0] === '__roml_items__' && Array.isArray(obj.__roml_items__)) return true;
-    if (keys[0] === '__roml_value__') return true;
-  }
+  // (1) resolved; no constraint needed.
 
   for (const [key, value] of Object.entries(obj)) {
     // (2) Backslash in key — resolved; no constraint needed.

--- a/src/lexer/RomlLexer.ts
+++ b/src/lexer/RomlLexer.ts
@@ -626,33 +626,58 @@ export class RomlLexer {
       }
     }
 
-    // Parse underscore style: _key_value_
+    // Parse underscore style: _key_value_. The shape is structurally
+    // ambiguous with any other KEY_VALUE syntax whose key and value
+    // both happen to start/end with `_` (e.g. DOLLAR for the
+    // synthetic-wrapper key `__roml_value__` with a special-value
+    // payload renders as `__roml_value__$__NULL__`, which starts and
+    // ends with `_`). Only claim the line as UNDERSCORE when no
+    // earlier KEY_VALUE separator outside quotes appears before the
+    // first `_` in the content — same precedence pattern as the
+    // colon-array fix in #27.
     if (line.startsWith('_') && line.endsWith('_')) {
       const content = line.slice(1, -1);
       const separatorPos = this.findSeparatorOutsideQuotes(content, '_');
       if (separatorPos !== -1) {
-        const keyPart = content.slice(0, separatorPos);
-        const valuePart = content.slice(separatorPos + 1);
-        const k = extractKey(keyPart);
+        // If any other KEY_VALUE separator appears outside quotes
+        // anywhere in the content, prefer that interpretation: the
+        // line is structurally another style whose key/value happen
+        // to be `_`-bounded. Without this, e.g. the encoder's
+        // DOLLAR output `__roml_value__$__NULL__` for a top-level
+        // null gets stolen by the UNDERSCORE parser because the
+        // line starts and ends with `_`.
+        const otherSeparators = ['=', ':', '~', '#', '%', '$', '^', '+'];
+        let hasOtherSeparator = false;
+        for (const sep of otherSeparators) {
+          if (this.findSeparatorOutsideQuotes(content, sep) !== -1) {
+            hasOtherSeparator = true;
+            break;
+          }
+        }
+        if (!hasOtherSeparator) {
+          const keyPart = content.slice(0, separatorPos);
+          const valuePart = content.slice(separatorPos + 1);
+          const k = extractKey(keyPart);
 
-        // `(.*)` so the empty quoted form `""` is recognised.
-        const quotedValueMatch = valuePart.match(/^"(.*)"$/);
-        if (quotedValueMatch) {
+          // `(.*)` so the empty quoted form `""` is recognised.
+          const quotedValueMatch = valuePart.match(/^"(.*)"$/);
+          if (quotedValueMatch) {
+            return [
+              k.key,
+              unescapeStringValue(quotedValueMatch[1]),
+              'UNDERSCORE',
+              k.wasQuoted,
+              k.hasPrimePrefix,
+            ];
+          }
           return [
             k.key,
-            unescapeStringValue(quotedValueMatch[1]),
+            this.parseSpecialValue(valuePart),
             'UNDERSCORE',
             k.wasQuoted,
             k.hasPrimePrefix,
           ];
         }
-        return [
-          k.key,
-          this.parseSpecialValue(valuePart),
-          'UNDERSCORE',
-          k.wasQuoted,
-          k.hasPrimePrefix,
-        ];
       }
     }
 

--- a/src/lexer/RomlLexer.ts
+++ b/src/lexer/RomlLexer.ts
@@ -632,9 +632,14 @@ export class RomlLexer {
     // synthetic-wrapper key `__roml_value__` with a special-value
     // payload renders as `__roml_value__$__NULL__`, which starts and
     // ends with `_`). Only claim the line as UNDERSCORE when no
-    // earlier KEY_VALUE separator outside quotes appears before the
-    // first `_` in the content — same precedence pattern as the
-    // colon-array fix in #27.
+    // other KEY_VALUE separator outside quotes appears anywhere in
+    // the content — same precedence-by-rejection pattern as the
+    // colon-array fix in #27, but checked across the full content
+    // rather than only before the first `_`, because (1) the first
+    // `_` in a synthetic-wrap line is at position 0 so "earlier"
+    // would be vacuous, and (2) any genuine UNDERSCORE-style line
+    // emitted by the encoder has only `_` as its structural
+    // separator.
     if (line.startsWith('_') && line.endsWith('_')) {
       const content = line.slice(1, -1);
       const separatorPos = this.findSeparatorOutsideQuotes(content, '_');

--- a/src/parser/RomlParser.ts
+++ b/src/parser/RomlParser.ts
@@ -78,6 +78,14 @@ export class RomlParser {
   private metaTagPresent: boolean = false;
   private primesDetected: boolean = false;
   private invalidPrimeKeys: string[] = [];
+  // Root-wrapper META state. Set by `checkForMetaTag` when the
+  // corresponding tag is seen in the document header. The unwrap
+  // logic consults these flags so that a user object whose only key
+  // happens to be `__roml_items__` / `__roml_value__` (without the
+  // META tag) is round-tripped as an object instead of being
+  // unwrapped.
+  private rootArrayWrapped: boolean = false;
+  private rootPrimitiveWrapped: boolean = false;
 
   public parse(tokens: RomlToken[]): RomlParseResult {
     this.tokens = tokens;
@@ -86,6 +94,8 @@ export class RomlParser {
     this.metaTagPresent = false;
     this.primesDetected = false;
     this.invalidPrimeKeys = [];
+    this.rootArrayWrapped = false;
+    this.rootPrimitiveWrapped = false;
 
     // Check for META tag
     this.checkForMetaTag();
@@ -94,6 +104,7 @@ export class RomlParser {
 
     // Validate prime consistency
     this.validatePrimeConsistency();
+    this.validateRootMetaConsistency();
 
     const data = this.astToData(ast);
 
@@ -336,13 +347,22 @@ export class RomlParser {
   }
 
   /**
-   * Unwrap synthetic objects back to their original types
+   * Unwrap synthetic objects back to their original types.
+   *
+   * The unwrap is META-tag-gated: the encoder emits
+   * `# ~META~ ROOT_ARRAY` or `# ~META~ ROOT_PRIMITIVE` whenever it
+   * synthetically wraps a non-object root, and only the presence of
+   * the matching META tag licenses the parser to unwrap. Without the
+   * tag, a wrapper-shaped user document (e.g. `{"__roml_items__":
+   * [1,2,3]}` written by hand) is round-tripped as a regular object
+   * rather than collapsed to an array.
    */
   private unwrapSyntheticObject(data: Record<string, any>): any {
     const keys = Object.keys(data);
 
     // Check for array wrapper: {"__roml_items__": [...]}
     if (
+      this.rootArrayWrapped &&
       keys.length === 1 &&
       keys[0] === SYNTHETIC_ITEMS_KEY &&
       Array.isArray(data[SYNTHETIC_ITEMS_KEY])
@@ -351,7 +371,11 @@ export class RomlParser {
     }
 
     // Check for primitive wrapper: {"__roml_value__": ...}
-    if (keys.length === 1 && keys[0] === SYNTHETIC_VALUE_KEY) {
+    if (
+      this.rootPrimitiveWrapped &&
+      keys.length === 1 &&
+      keys[0] === SYNTHETIC_VALUE_KEY
+    ) {
       return data[SYNTHETIC_VALUE_KEY];
     }
 
@@ -437,22 +461,22 @@ export class RomlParser {
   }
 
   private checkForMetaTag(): void {
-    // Look for META tag in HEADER token or in the raw value of tokens
+    // Look for META tags in HEADER tokens or in the raw value of
+    // tokens. A document can carry several META tags simultaneously
+    // (e.g. a top-level array of primes carries both ROOT_ARRAY and
+    // SIEVE_OF_ERATOSTHENES_INVOKED), so we don't break on the
+    // first match — keep scanning to set every flag we see.
     for (const token of this.tokens) {
-      if (token.type === 'HEADER' && token.value) {
-        if (token.value.includes(`~META~ ${MetaTags.SIEVE_OF_ERATOSTHENES_INVOKED}`)) {
-          this.metaTagPresent = true;
-          break;
-        }
-      }
-      // Also check in the raw token value in case it's in a comment-style line
-      if (
-        token.value &&
-        typeof token.value === 'string' &&
-        token.value.includes(`~META~ ${MetaTags.SIEVE_OF_ERATOSTHENES_INVOKED}`)
-      ) {
+      const value = token.value;
+      if (typeof value !== 'string') continue;
+      if (value.includes(`~META~ ${MetaTags.SIEVE_OF_ERATOSTHENES_INVOKED}`)) {
         this.metaTagPresent = true;
-        break;
+      }
+      if (value.includes(`~META~ ${MetaTags.ROOT_ARRAY}`)) {
+        this.rootArrayWrapped = true;
+      }
+      if (value.includes(`~META~ ${MetaTags.ROOT_PRIMITIVE}`)) {
+        this.rootPrimitiveWrapped = true;
       }
     }
   }
@@ -469,6 +493,26 @@ export class RomlParser {
       this.errors.push(
         `Document declares ~META~ ${MetaTags.SIEVE_OF_ERATOSTHENES_INVOKED} but contains no prime-prefixed keys. ` +
           'Remove the META tag or add prime prefixes (!) to keys with prime number values.'
+      );
+    }
+  }
+
+  /**
+   * Validate the root-wrapper META tags against the parsed document
+   * shape. A `ROOT_ARRAY` declaration must accompany a single-key
+   * `__roml_items__: [...]` payload; a `ROOT_PRIMITIVE` declaration
+   * must accompany a single-key `__roml_value__: x` payload. The two
+   * wrappers are mutually exclusive. Surfacing these as parse errors
+   * keeps malformed documents from silently degrading.
+   *
+   * The check happens after `buildAST` but before `astToData`, so
+   * `this.tokens`-derived flags are populated and the unwrap logic
+   * can still trust the metadata.
+   */
+  private validateRootMetaConsistency(): void {
+    if (this.rootArrayWrapped && this.rootPrimitiveWrapped) {
+      this.errors.push(
+        `Document declares both ~META~ ${MetaTags.ROOT_ARRAY} and ~META~ ${MetaTags.ROOT_PRIMITIVE}; only one root-wrapper tag may appear.`
       );
     }
   }

--- a/src/parser/RomlParser.ts
+++ b/src/parser/RomlParser.ts
@@ -498,16 +498,18 @@ export class RomlParser {
   }
 
   /**
-   * Validate the root-wrapper META tags against the parsed document
-   * shape. A `ROOT_ARRAY` declaration must accompany a single-key
-   * `__roml_items__: [...]` payload; a `ROOT_PRIMITIVE` declaration
-   * must accompany a single-key `__roml_value__: x` payload. The two
-   * wrappers are mutually exclusive. Surfacing these as parse errors
-   * keeps malformed documents from silently degrading.
+   * Validate that the root-wrapper META tags are mutually exclusive.
+   * A document may declare `ROOT_ARRAY` or `ROOT_PRIMITIVE`, not
+   * both, since they describe contradictory wrap shapes.
    *
-   * The check happens after `buildAST` but before `astToData`, so
-   * `this.tokens`-derived flags are populated and the unwrap logic
-   * can still trust the metadata.
+   * Shape-level validation (`ROOT_ARRAY` requires a single-key
+   * `__roml_items__: [...]` payload, etc.) is intentionally not
+   * performed here; if a hand-written document declares the META
+   * but ships a different shape, `unwrapSyntheticObject` will
+   * simply not unwrap, and the user gets back the literal payload
+   * they wrote. That degrades silently to "regular object" rather
+   * than throwing, which preserves the loose-parsing posture of the
+   * format.
    */
   private validateRootMetaConsistency(): void {
     if (this.rootArrayWrapped && this.rootPrimitiveWrapped) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,21 @@
  */
 export enum MetaTags {
   SIEVE_OF_ERATOSTHENES_INVOKED = 'SIEVE_OF_ERATOSTHENES_INVOKED',
+  /**
+   * Marks a document whose JSON root was an array. The encoder wraps
+   * such roots as `{__roml_items__: [...]}` for downstream encoding,
+   * and this META tag is what tells the parser the wrap is synthetic
+   * (so a user document with a real `__roml_items__` key as its only
+   * top-level key does not get unwrapped).
+   */
+  ROOT_ARRAY = 'ROOT_ARRAY',
+  /**
+   * Marks a document whose JSON root was a primitive (string, number,
+   * boolean, null). The encoder wraps such roots as
+   * `{__roml_value__: x}`. As with ROOT_ARRAY, the META tag is what
+   * licenses the parser to unwrap.
+   */
+  ROOT_PRIMITIVE = 'ROOT_PRIMITIVE',
 }
 
 /**


### PR DESCRIPTION
## Summary

Resolves fuzz limitations **#1** and **#15** from the round-trip property suite. The two are entangled (the fix for #1 activates #15), so they're addressed together. An adjacent encoder fix for values ending in `]`/`}` was also folded in for the same reason.

### Limitation #1: Synthetic-wrapper collision

The encoder wraps top-level non-objects as `{__roml_items__: [...]}` or `{__roml_value__: x}` so the rest of the encoder can assume an object root. The parser used to unconditionally unwrap any single-key object whose key matched a wrapper sentinel, which meant a user document with the wrapper sentinel as a real key was structurally indistinguishable from an encoder wrap and got silently collapsed:

```
{"__roml_items__": [1, 2, 3]}  -> ROML -> [1, 2, 3]   // data lost
```

**Fix:** emit a META tag in the document header when the encoder synthetically wraps. The parser only unwraps when the matching tag is present.

- `MetaTags.ROOT_ARRAY` and `MetaTags.ROOT_PRIMITIVE` added in `src/types.ts`.
- Encoder pushes the matching tag into `headerLines` whenever `inputType` is `'array'` or `'primitive'`.
- Parser tracks `rootArrayWrapped` / `rootPrimitiveWrapped` flags via `checkForMetaTag`, and `unwrapSyntheticObject` consults them. New `validateRootMetaConsistency` errors when both root META tags are declared.
- The `isSyntheticWrapperKey` short-circuits in `objectContainsPrimesExcludingWrapperKeys` and `analyzeLineFeatures` are now gated on `inputType !== 'object'` (passed via `documentFeatures.rootType`), so user objects with wrapper-shape keys don't accidentally suppress prime detection.

### Limitation #15: Underscore-bounded line collision

Adding the META tag bumps the data-line counter parity for top-level primitives — `null` lands on counter=2 (even) and the encoder picks DOLLAR style. The output `__roml_value__$__NULL__` starts and ends with `_`, and the lexer's UNDERSCORE-style parser preempted the structural `$` separator.

**Fix:** in `parseSpecialCases`, only claim UNDERSCORE when no other KEY_VALUE separator appears outside quotes anywhere in the content. Same precedence pattern as the colon-array fix in #27.

### Adjacent fix — `]` and `}` at value end

While shifting parities, an encoder shape like `"[0]"=,]` (EQUALS with a value containing `,` and ending in `]`) tripped the lexer's greedy `jsonArrayMatch` regex. Extended `isAmbiguousString` to flag values ending in `]` or `}` (already flagged `[` and `{`), routing them through QUOTED.

## BC break

**Yes** (pre-1.0). ROML produced before this PR for non-object roots had the wrap but no META tag; that output now decodes as a regular `{__roml_items__: [...]}` object instead of unwrapping. The synthetic wrapper has only existed since #11 and the renamed sentinels haven't been a stable contract.

## Failing tests (added in this PR)

```ts
// src/__tests__/RootMetaTag.test.ts (15 tests)
describe('encoder emits the META tag for synthetic wraps', () => {
  it('emits ROOT_ARRAY when the input is a top-level array', ...);
  it('emits ROOT_PRIMITIVE when the input is a top-level primitive', ...);
  it('does NOT emit a root-wrapper META for object roots', ...);
  it('does NOT emit a root-wrapper META for objects whose key happens to be the sentinel', ...);
});
describe('round-trip for genuine non-object roots', ...);
describe('user objects with wrapper-key shapes round-trip intact', () => {
  it('round-trips `{"__roml_items__": [...]}` as an object, not an array', ...);
  it('round-trips `{"__roml_value__": x}` as an object, not the inner value', ...);
  it('round-trips an object containing both wrapper sentinels as keys', ...);
  it('round-trips a wrapper-shape object inside a deeper structure', ...);
});
describe('hand-written ROML decoding', () => {
  it('without ROOT_ARRAY META, a `__roml_items__` single-key shape decodes as an object', ...);
  it('with ROOT_ARRAY META, the same payload decodes as the unwrapped array', ...);
  it('with ROOT_PRIMITIVE META, a `__roml_value__` payload decodes as the unwrapped primitive', ...);
  it('declaring both ROOT_ARRAY and ROOT_PRIMITIVE is a parse error', ...);
});
```

Before fix: 5 of 15 fail. After fix: 15 of 15 pass.

## Files touched

- `src/types.ts` — two new `MetaTags` enum values.
- `src/RomlConverter.ts` — header emit for root META; `analyzeDocumentFeatures` accepts `inputType` and threads `rootType` into `DocumentFeatures`; `analyzeLineFeatures` only suppresses prime-prefix on synthetic wraps; `isAmbiguousString` flags `]`/`}` trailing.
- `src/lexer/RomlLexer.ts` — `parseSpecialCases` UNDERSCORE branch tightened with the "no other separator outside quotes" guard.
- `src/parser/RomlParser.ts` — `rootArrayWrapped` / `rootPrimitiveWrapped` flags, `unwrapSyntheticObject` gated on them, `validateRootMetaConsistency` for the dual-tag error.
- `src/__tests__/RootMetaTag.test.ts` — regression coverage.
- `src/__tests__/RoundTripFuzz.test.ts` — drop limitation #1; include the wrapper sentinels in `stressKey`.

## Test plan

- [x] `npm install && npm run build && npm run lint && npm test` — 395 tests pass (was 380 + 15 new), lint and build clean.
- [x] Fuzz still passes under the pinned seed (`20260507`, 100 runs per property) with limitation #1 removed and the wrapper sentinels added to the stress arbitrary.
- [x] Smoke: `node -e 'import("./dist/file/RomlFile.js").then(m=>console.log(JSON.stringify(m.RomlFile.romlToJson(m.RomlFile.jsonToRoml({__roml_items__:[1,2,3]})))))'` returns `{"__roml_items__":[1,2,3]}` rather than `[1,2,3]`. Top-level arrays and primitives still round-trip via the META + wrap.

Of the original 15 fuzz limitations, this PR resolves **#1** and **#15**. Remaining: #3 (single-element array ambiguity, architectural), #4 (empty arrays in non-PIPES), #9 / #11 / #12 / #13 / #14 (per-style item escaping family).

https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV)_