### PR TITLE
fix(encoder): skip COLLECTIONS-PIPES override for scalar values (limitation #13)

### DIFF
--- a/src/RomlConverter.ts
+++ b/src/RomlConverter.ts
@@ -639,8 +639,24 @@ export class RomlConverter {
     // styles (notably PERSONAL → QUOTED) wrap the value in double
     // quotes and would coerce non-strings (booleans, numbers) into
     // string round-trips (limitation #7).
+    //
+    // PIPES (the COLLECTIONS-category style) is also skipped here:
+    // its KV template `||${key}||${value}||` is byte-for-byte
+    // identical to a single-item PIPES array's emission, so a
+    // scalar string under a COLLECTIONS key (`tags`, `items`, ...)
+    // would emit a line the lexer parses as `{||key: value}` —
+    // the leading `||` of the wrapper gets reattached to the key.
+    // Fall through to the value-type branches and let them pick a
+    // non-PIPES KV style instead (limitation #13). Arrays under
+    // COLLECTIONS keys go through `selectArrayStyle`, not this
+    // function, so they keep their existing PIPES-or-other routing.
     const semanticStyle = this.getSemanticStyle(key);
-    if (semanticStyle && !isEvenLine && valueType === 'string') {
+    if (
+      semanticStyle &&
+      !isEvenLine &&
+      valueType === 'string' &&
+      semanticStyle !== 'PIPES'
+    ) {
       return SYNTAX_STYLES[semanticStyle];
     }
 

--- a/src/__tests__/CollectionsKeyNonArrayValue.test.ts
+++ b/src/__tests__/CollectionsKeyNonArrayValue.test.ts
@@ -113,14 +113,47 @@ describe('COLLECTIONS-key scalar values skip the PIPES override', () => {
   });
 
   describe('regression: other semantic categories still apply their override', () => {
-    it('round-trips {name:"alice"} (PERSONAL → QUOTED)', () => {
-      const input = { name: 'alice' };
-      expect(roundTrip(input)).toEqual(input);
+    // These cases assert against the EMITTED ROML, not just the
+    // round-trip equality, because round-trip alone would pass
+    // even if the override silently stopped applying — every
+    // semantic style produces a different shape, and as long as
+    // each shape round-trips, equality wouldn't catch a regression.
+    // Asserting on the emitted ROML pins the style choice.
+
+    it('PERSONAL keys still route to QUOTED (`name="alice"`)', () => {
+      const roml = RomlFile.jsonToRoml({ name: 'alice' });
+      expect(roml).toContain('name="alice"');
+      expect(roundTrip({ name: 'alice' })).toEqual({ name: 'alice' });
     });
 
-    it('round-trips {active:"yes"} (STATUS)', () => {
-      const input = { active: 'yes' };
-      expect(roundTrip(input)).toEqual(input);
+    it('STATUS keys still route to BRACKETS (`active<"yes">`)', () => {
+      const roml = RomlFile.jsonToRoml({ active: 'yes' });
+      expect(roml).toContain('active<');
+      expect(roundTrip({ active: 'yes' })).toEqual({ active: 'yes' });
+    });
+
+    it('TECHNICAL keys still route to AMPERSAND (`&id&abc`)', () => {
+      const roml = RomlFile.jsonToRoml({ id: 'abc' });
+      expect(roml).toContain('&id&');
+      expect(roundTrip({ id: 'abc' })).toEqual({ id: 'abc' });
+    });
+  });
+
+  describe('regression: COLLECTIONS keys no longer route scalars to PIPES KV', () => {
+    // Asserting on the emitted ROML rather than just round-trip
+    // equality — the previous PIPES-KV emission was structurally
+    // distinguishable (`||tags||plain||`), so explicitly checking
+    // the output does NOT start with `||` confirms the override
+    // skip is what's doing the work, not some other accident.
+
+    it('{tags:"plain"} no longer emits a `||tags||...||` PIPES line', () => {
+      const roml = RomlFile.jsonToRoml({ tags: 'plain' });
+      expect(roml).not.toMatch(/^\|\|tags\|\|/m);
+    });
+
+    it('{items:"x"} no longer emits a `||items||...||` PIPES line', () => {
+      const roml = RomlFile.jsonToRoml({ items: 'x' });
+      expect(roml).not.toMatch(/^\|\|items\|\|/m);
     });
   });
 });

--- a/src/__tests__/CollectionsKeyNonArrayValue.test.ts
+++ b/src/__tests__/CollectionsKeyNonArrayValue.test.ts
@@ -1,0 +1,126 @@
+import { RomlFile } from '../file/RomlFile';
+
+describe('COLLECTIONS-key scalar values skip the PIPES override', () => {
+  // Regression for fuzz limitation #13.
+  //
+  // `SEMANTIC_CATEGORIES.COLLECTIONS` ({tags, items, list, array,
+  // elements, values, data}) was mapped to PIPES via
+  // `getSemanticStyle`, and `selectSyntax` applied that override
+  // for any string value (after limitation #7 added the
+  // `valueType === 'string'` gate). The PIPES KV template
+  // `||${key}||${value}||` is byte-for-byte identical to a
+  // single-item PIPES array's emission, so a scalar value under
+  // a COLLECTIONS key emitted an ambiguous line that the lexer's
+  // `^(.+?)\|\|(.*)\|\|$` regex (lazy on the key, greedy on the
+  // value) reattached the leading `||` of the PIPES wrapper to
+  // the key:
+  //
+  //   {tags: "plain"} -> ||tags||plain|| -> {"||tags": "plain"}
+  //
+  // Fix: skip the COLLECTIONS-PIPES override for scalar string
+  // values. Other semantic styles (PERSONAL → QUOTED, STATUS, ...)
+  // round-trip strings cleanly via their existing escape
+  // pipelines, so they stay applied.
+  //
+  // Arrays under COLLECTIONS keys are unaffected — array styling
+  // goes through `selectArrayStyle`, not `selectSyntax`.
+
+  function roundTrip(input: unknown): unknown {
+    return RomlFile.romlToJson(RomlFile.jsonToRoml(input));
+  }
+
+  describe('every COLLECTIONS keyword as a scalar string value', () => {
+    it('round-trips {tags:"x"}', () => {
+      const input = { tags: 'x' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips {items:"x"}', () => {
+      const input = { items: 'x' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips {list:"x"}', () => {
+      const input = { list: 'x' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips {array:"x"}', () => {
+      const input = { array: 'x' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips {elements:"x"}', () => {
+      const input = { elements: 'x' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips {values:"x"}', () => {
+      const input = { values: 'x' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips {data:"x"}', () => {
+      const input = { data: 'x' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+
+  describe('edge values that previously confused the PIPES KV path', () => {
+    it('round-trips {tags:""}', () => {
+      const input = { tags: '' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips {tags:"||"}', () => {
+      const input = { tags: '||' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips {tags:"a||b"}', () => {
+      const input = { tags: 'a||b' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips {tags:"plain text with spaces"}', () => {
+      const input = { tags: 'plain text with spaces' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+
+  describe('mixed-case keys (override uses lowerKey)', () => {
+    it('round-trips {Tags:"x"}', () => {
+      const input = { Tags: 'x' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips {TAGS:"x"}', () => {
+      const input = { TAGS: 'x' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+
+  describe('regression: arrays under COLLECTIONS keys still work', () => {
+    it('round-trips {tags:["a","b"]}', () => {
+      const input = { tags: ['a', 'b'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips {items:["a","b","c"]}', () => {
+      const input = { items: ['a', 'b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+
+  describe('regression: other semantic categories still apply their override', () => {
+    it('round-trips {name:"alice"} (PERSONAL → QUOTED)', () => {
+      const input = { name: 'alice' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips {active:"yes"} (STATUS)', () => {
+      const input = { active: 'yes' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+});

--- a/src/__tests__/RoundTripFuzz.test.ts
+++ b/src/__tests__/RoundTripFuzz.test.ts
@@ -220,12 +220,13 @@ describe('Round-trip property tests (fast-check)', () => {
  *     non-COLLECTIONS keys round-trip through the existing
  *     unquoted-style paths because their separators don't include
  *     `|`.)
- * 13. COLLECTIONS-category key (`tags`, `items`, `list`, ...) with a
- *     non-array value: the encoder routes these through
- *     `SYNTAX_STYLES.PIPES` which renders `||key||value||` —
- *     structurally identical to a primitive PIPES array with key
- *     `||key` and value `value`, so the lexer mis-parses. Same
- *     family as limitation 7.
+ * 13. (Resolved — `selectSyntax` now skips the COLLECTIONS-PIPES
+ *     override for scalar string values, since the PIPES KV
+ *     template is byte-for-byte identical to a single-item PIPES
+ *     array's emission. Scalars under COLLECTIONS keys fall
+ *     through to the value-type branches and pick a non-PIPES
+ *     KV style. Array values under those keys still go through
+ *     `selectArrayStyle` and keep their existing routing.)
  * 14. Array items containing separator characters that aren't
  *     escaped by the corresponding inline style — `:` (COLON_DELIM),
  *     `>` (BRACKETS, see #9), `"` (JSON_STYLE, see #11). `|` (PIPES)
@@ -254,16 +255,6 @@ describe('Round-trip property tests (fast-check)', () => {
  *     constraints just shifted the seed sequence so fast-check
  *     happens to surface this case now.
  */
-const COLLECTION_KEYS = new Set([
-  'tags',
-  'items',
-  'list',
-  'array',
-  'elements',
-  'values',
-  'data',
-]);
-
 /**
  * Per-item screens that apply to any array (whether the array is the
  * top-level input or stored under an object key). Limitations
@@ -360,11 +351,10 @@ function hasKnownLimitation(input: unknown): boolean {
     //      `|`-bearing values under COLLECTIONS keys are still
     //      constrained out by (13) below.
 
-    // (13) COLLECTIONS-category key with a non-array value — PIPES
-    //      KEY_VALUE shape collides with PIPES primitive-array shape.
-    if (COLLECTION_KEYS.has(key.toLowerCase()) && !Array.isArray(value)) {
-      return true;
-    }
+    // (13) Resolved — `selectSyntax` now skips the COLLECTIONS-PIPES
+    //      override for scalar string values, so a scalar value
+    //      under a COLLECTIONS key picks a non-PIPES KV style and
+    //      round-trips cleanly.
 
     // (14) Array items containing un-escaped inline-array separator
     //      chars: `:`, `>`, `"` (already covered by #11 but restated

--- a/src/__tests__/RoundTripFuzz.test.ts
+++ b/src/__tests__/RoundTripFuzz.test.ts
@@ -214,12 +214,10 @@ describe('Round-trip property tests (fast-check)', () => {
  * 12. (Resolved for arrays — the PIPES array emitter now quotes
  *     items containing `|`, and the lexer's PIPES content split is
  *     quote-aware via `splitOutsideQuotes`, so `||` inside a quoted
- *     item is preserved as part of the item. Non-array `|`-bearing
- *     string values under COLLECTIONS-category keys are still
- *     constrained out under #13; non-array `|`-bearing values under
- *     non-COLLECTIONS keys round-trip through the existing
- *     unquoted-style paths because their separators don't include
- *     `|`.)
+ *     item is preserved as part of the item. Scalar `|`-bearing
+ *     strings under any key — including COLLECTIONS keys, after
+ *     #13 — round-trip through their respective non-PIPES KV
+ *     styles because those styles' separators don't include `|`.)
  * 13. (Resolved — `selectSyntax` now skips the COLLECTIONS-PIPES
  *     override for scalar string values, since the PIPES KV
  *     template is byte-for-byte identical to a single-item PIPES
@@ -345,11 +343,9 @@ function hasKnownLimitation(input: unknown): boolean {
     }
 
     // (12) Resolved for arrays — see top-level docstring. Scalar
-    //      `|`-bearing values under non-COLLECTIONS keys already
-    //      round-trip via the existing FAKE_COMMENT/EQUALS/etc.
-    //      paths whose separators don't include `|`. Scalar
-    //      `|`-bearing values under COLLECTIONS keys are still
-    //      constrained out by (13) below.
+    //      `|`-bearing strings under any key (including COLLECTIONS
+    //      keys after the #13 fix) round-trip via the value-type
+    //      KV branches whose separators don't include `|`.
 
     // (13) Resolved — `selectSyntax` now skips the COLLECTIONS-PIPES
     //      override for scalar string values, so a scalar value


### PR DESCRIPTION
Limitation #13 in the property-based fuzz: a scalar string value
under a COLLECTIONS-category key (`tags`, `items`, `list`, `array`,
`elements`, `values`, `data`) round-tripped with the wrapper bytes
attached to the key —

  {tags: "plain"} -> ||tags||plain|| -> {"||tags": "plain"}

The PIPES KV template `||${key}||${value}||` is byte-for-byte
identical to a single-item PIPES array's emission, so the lexer's
lazy/greedy `^(.+?)\|\|(.*)\|\|$` regex reattached the leading
`||` of the wrapper to the key. Lexer can't disambiguate the
shape; the fix is to stop the encoder from emitting it.

Fix: add `semanticStyle !== 'PIPES'` to the COLLECTIONS-override
guard in `selectSyntax`. When the override is skipped, scalar
strings fall through to the value-type branches and pick a
non-PIPES KV style (FAKE_COMMENT for odd lines, EQUALS for even
lines, etc.). All of those use a single key/value separator
distinct from `||`, so the round-trip is unambiguous.

Other semantic categories (PERSONAL → QUOTED, STATUS, TECHNICAL,
FINANCIAL, TEMPORAL) still apply — only PIPES is structurally an
array shape. Arrays under COLLECTIONS keys are unaffected because
array styling goes through `selectArrayStyle`, not `selectSyntax`.

Tests:

- New `src/__tests__/CollectionsKeyNonArrayValue.test.ts` (17
  cases): one per COLLECTIONS keyword as a scalar; edge values
  (`""`, `"||"`, `"a||b"`, "plain text with spaces"); mixed-case
  keys (override uses `lowerKey`); array-value no-regression for
  `tags`/`items`; other-category no-regression for `name`
  (PERSONAL → QUOTED) and `active` (STATUS).
- `src/__tests__/RoundTripFuzz.test.ts`: drop the (13) constraint
  branch, mark resolved in the docstring counter, remove the now-
  orphaned `COLLECTION_KEYS` constant. Pinned-seed fuzz still
  green.

422 tests pass, lint clean. CLI smoke for `{"tags":"plain"}` now
encodes as `//tags//plain` (FAKE_COMMENT) instead of the ambiguous
`||tags||plain||`.

BC break: yes (cosmetic). ROML produced before this PR for a
COLLECTIONS-key scalar value used PIPES KV; after this PR it uses
whatever non-PIPES style the parity-and-value-type branches pick.
This is a forward-only encoder change — the lexer still handles
every shape it did before, so older ROML continues to decode (the
broken way).

https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV