### PR TITLE
fix(lexer): single-pass unescapeStringValue (limitation #16)

### DIFF
--- a/src/__tests__/EscapeSequenceLiterals.test.ts
+++ b/src/__tests__/EscapeSequenceLiterals.test.ts
@@ -1,0 +1,113 @@
+import { RomlFile } from '../file/RomlFile';
+
+describe('Literal escape sequences in keys and values', () => {
+  // Regression for fuzz limitation #16.
+  //
+  // `unescapeStringValue` (src/lexer/RomlLexer.ts) used a chained
+  // `.replace()` pipeline (`\\n` → newline, `\\r` → CR, `\\t` → tab,
+  // `\\"` → `"`, `\\\\` → `\`) that doesn't compose for the literal
+  // 2-byte sequences `\n` / `\r` / `\t` (backslash followed by the
+  // letter `n` / `r` / `t` — NOT the control char).
+  //
+  // Trace for a user key `\n` (2 bytes: `\`, `n`):
+  //   - encoder `escapeForRoml` doubles `\` → `\\`, emits 3 bytes
+  //     `\\n` (`\`, `\`, `n`).
+  //   - lexer `unescapeStringValue`:
+  //       step 1 `/\\n/g` → newline matches the LAST 2 bytes
+  //       (`\`+`n`), leaves `\` + newline (2 bytes, newline embedded).
+  //       step 5 `/\\\\/g` → `\` has nothing to match.
+  //   - round-trip: `\n` (2 bytes) → `\` + newline.
+  //
+  // Fix: rewrite `unescapeStringValue` as a single-pass walker
+  // (`/\\(.)/g` with an escape-map callback) so each `\X` pair is
+  // resolved atomically. Same function feeds keys (extractKey) and
+  // quoted values across every syntax style, so one rewrite fixes
+  // every code path.
+
+  function roundTrip(input: unknown): unknown {
+    return RomlFile.romlToJson(RomlFile.jsonToRoml(input));
+  }
+
+  describe('literal escape sequences in keys', () => {
+    it('round-trips {"\\\\n":1} (key is two bytes: `\\`, `n`)', () => {
+      const input = { '\\n': 1 };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips {"\\\\r":1}', () => {
+      const input = { '\\r': 1 };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips {"\\\\t":1}', () => {
+      const input = { '\\t': 1 };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips {"a\\\\nb":"x"} (literal `\\n` mid-key)', () => {
+      const input = { 'a\\nb': 'x' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips {"\\\\\\\\n":1} (literal `\\\\n`: backslash, backslash, n)', () => {
+      const input = { '\\\\n': 1 };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips {"\\\\":0} (lone backslash, no regression)', () => {
+      const input = { '\\': 0 };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+
+  describe('literal escape sequences in values (forced through QUOTED path)', () => {
+    // `\n` / `\r` / `\t` alone in a value don't trigger
+    // `isAmbiguousString`, so they emit unquoted and skip
+    // `unescapeStringValue` entirely. Combining the literal
+    // escape with a value-shape that DOES force quoting (a
+    // leading `"`, a trailing `]`, etc.) is what surfaces the
+    // mangling on the value side.
+
+    it('round-trips a value with leading `"` and literal `\\n`', () => {
+      const input = { x: '"\\n' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips a value ending in `]` with literal `\\n`', () => {
+      const input = { x: '\\n]' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips a value ending in `}` with literal `\\r`', () => {
+      const input = { x: '\\r}' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips a value with trailing `"` and literal `\\t`', () => {
+      const input = { x: '\\t"' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+
+  describe('control chars (must still round-trip — the rewrite preserves them)', () => {
+    it('round-trips a real newline char in a value', () => {
+      const input = { x: 'line1\nline2' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips a real tab char in a value', () => {
+      const input = { x: 'col1\tcol2' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips a real CR char in a value', () => {
+      const input = { x: 'a\rb' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips an embedded `"` in a value', () => {
+      const input = { x: 'say "hi"' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+});

--- a/src/__tests__/RoundTripFuzz.test.ts
+++ b/src/__tests__/RoundTripFuzz.test.ts
@@ -237,21 +237,17 @@ describe('Round-trip property tests (fast-check)', () => {
  *     `_` plus a `__NULL__` / `__EMPTY__` / `__UNDEFINED__` sentinel
  *     value (which themselves start/end with `_`) emits a line like
  *     `_=__NULL__` that the lexer's UNDERSCORE parser claims first.
- * 16. Pre-existing unescape-ordering bug surfaced by relaxed #12/#14
- *     constraints: a key containing the literal 2-char sequences
- *     `\n`, `\r`, or `\t` (backslash followed by `n`/`r`/`t`) is
- *     routed through the QUOTED-key escape pipeline. The encoder's
- *     `escapeForRoml` doubles the leading `\` to `\\`, but the
- *     lexer's chained-replace `unescapeStringValue` matches `\\n` /
- *     `\\r` / `\\t` (3 bytes — the doubled backslash plus the
- *     letter) as the 2-byte escaped form `\n` / `\r` / `\t` BEFORE
- *     the final `\\\\ -> \\` step reverses the doubled backslash,
- *     so the literal mangles into a `\` + control-char pair on
- *     round-trip. Same family of issue as the limitation #11
- *     JSON_STYLE escape mismatch; both want a single-pass walker.
- *     This is independent of the limitation #12 fix; the relaxed
- *     constraints just shifted the seed sequence so fast-check
- *     happens to surface this case now.
+ * 16. (Resolved — `unescapeStringValue` is now a single-pass
+ *     `/\\(.)/g` + escape-map walker, so each `\X` pair is
+ *     resolved atomically. The chained `.replace()` pipeline
+ *     used to mangle literal `\n` / `\r` / `\t` 2-byte
+ *     sequences in keys and quoted values because the
+ *     `\\n -> newline` step would consume the `\n` portion of
+ *     a doubled-backslash source before the `\\\\ -> \\` step
+ *     could reverse the doubling. Walker form resolves each
+ *     escape pair before moving on, eliminating the ordering
+ *     trap. Same fix applies to limitation #11's JSON_STYLE
+ *     escape mismatch as a small follow-up.)
  */
 /**
  * Per-item screens that apply to any array (whether the array is the
@@ -374,12 +370,10 @@ function hasKnownLimitation(input: unknown): boolean {
       return true;
     }
 
-    // (16) Pre-existing unescape-ordering bug — see top-level
-    //      docstring. Until `unescapeStringValue` is rewritten as a
-    //      single-pass walker, any key containing literal `\n`,
-    //      `\r`, or `\t` (the 2-char sequence, not the control
-    //      char) mangles on round-trip through the QUOTED-key path.
-    if (/\\[nrt]/.test(key)) return true;
+    // (16) Resolved — see top-level docstring. `unescapeStringValue`
+    //      is a single-pass walker now, so each `\X` pair is
+    //      resolved atomically and literal `\n`/`\r`/`\t` sequences
+    //      survive the round-trip through the QUOTED escape path.
 
     if (hasKnownLimitation(value)) return true;
   }

--- a/src/lexer/RomlLexer.ts
+++ b/src/lexer/RomlLexer.ts
@@ -13,15 +13,38 @@ interface ExtractedKey {
 }
 
 /**
- * Unescape string from ROML format - convert escape sequences back to actual characters
+ * Map of escape-letter to the bytes it decodes to. Used by
+ * `unescapeStringValue` to resolve each `\X` pair atomically.
+ */
+const ESCAPE_MAP: Record<string, string> = {
+  n: '\n',
+  r: '\r',
+  t: '\t',
+  '"': '"',
+  '\\': '\\',
+};
+
+/**
+ * Unescape a string from ROML's escape form.
+ *
+ * Walks the input with a single regex pass (`/\\(.)/g`) so each
+ * `\X` pair is resolved atomically — earlier versions used a
+ * chained `.replace()` pipeline whose ordering couldn't compose
+ * for the literal 2-char sequences `\n` / `\r` / `\t`: the
+ * `\\n` → newline step would consume the `\n` portion of a
+ * doubled-`\` + `n` source (`\\n`, 3 bytes from the encoder's
+ * doubling pass) before the `\\\\` → `\` step could reverse the
+ * doubling. Result: user input `\` + `n` (2 bytes) mangled to
+ * `\` + newline on round-trip (limitation #16).
+ *
+ * Unknown escapes (`\X` where X is not in the map) are left
+ * verbatim — matches the encoder's behaviour of only escaping
+ * the chars it knows.
  */
 function unescapeStringValue(value: string): string {
-  return value
-    .replace(/\\n/g, '\n') // Unescape newlines
-    .replace(/\\r/g, '\r') // Unescape carriage returns
-    .replace(/\\t/g, '\t') // Unescape tabs
-    .replace(/\\"/g, '"') // Unescape quotes
-    .replace(/\\\\/g, '\\'); // Unescape backslashes (must be last)
+  return value.replace(/\\(.)/g, (match, char: string) =>
+    Object.prototype.hasOwnProperty.call(ESCAPE_MAP, char) ? ESCAPE_MAP[char] : match
+  );
 }
 
 export interface RomlToken {


### PR DESCRIPTION
## Summary

Limitation #16 in the property-based fuzz: literal 2-char escape sequences (`\n`, `\r`, `\t` — backslash followed by the letter, NOT the control char) in keys or quoted values mangled on round-trip because the lexer's `unescapeStringValue` used a chained `.replace()` pipeline whose ordering didn't compose.

Trace for user key `\n` (2 bytes: `\`, `n`):
- Encoder `escapeForRoml` doubles `\` → `\\`, emits `\\n` (3 bytes).
- Lexer chain ran `/\\n/g → newline` first, which matched the LAST 2 bytes of the 3-byte input, leaving `\` + newline. The final `/\\\\/g → \` step then had nothing to do.
- Result: 2-byte `\n` mangled to `\` + newline.

Fix: rewrite `unescapeStringValue` as a single regex pass `/\\(.)/g` with an `ESCAPE_MAP` callback so each `\X` pair is resolved atomically. Same function feeds keys (`extractKey`) and quoted values across every syntax style, so one rewrite removes the bug from every code path.

## Failing test snippet (now passing)

```ts
// src/__tests__/EscapeSequenceLiterals.test.ts
it('round-trips {"\\\\n":1} (key is two bytes: `\\`, `n`)', () => {
  const input = { '\\n': 1 };
  expect(roundTrip(input)).toEqual(input);
});
```

Pre-fix: round-trip returned `{ "\n": 1 }` (newline char) instead of `{ "\\n": 1 }` (literal `\`+`n`).

## Test plan

- [x] `npm test` — 439 tests pass (14 new in `EscapeSequenceLiterals.test.ts`, up from 425).
- [x] `npm run lint` — clean.
- [x] `npm run build` — TypeScript clean.
- [x] Pinned fuzz (`seed: 20260507, numRuns: 100`) green after dropping the `/\\[nrt]/.test(key)` screen.
- [x] CLI smoke: `echo '{"\\n":1}' | node dist/cli.js encode | node dist/cli.js decode` returns `{"\\n": 1}` identically.

BC break: no. The walker is byte-equivalent on all currently-tested shapes — only previously-mangled sequences (which the fuzz screen was hiding) start round-tripping correctly. Old ROML continues to decode the same way it always did for non-pathological input.

Unblocks limitation #11 (JSON_STYLE escape mismatch) as a small follow-up.

https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV)_