### PR TITLE
fix(lexer): JSON.parse JSON_STYLE items + tighten escape handling (#11)

### DIFF
--- a/src/__tests__/JsonStyleEscapes.test.ts
+++ b/src/__tests__/JsonStyleEscapes.test.ts
@@ -1,0 +1,131 @@
+import { RomlFile } from '../file/RomlFile';
+
+describe('JSON_STYLE array items: encoder/decoder escape symmetry', () => {
+  // Regression for fuzz limitation #11.
+  //
+  // The JSON_STYLE array emitter (src/RomlConverter.ts ~line 510)
+  // emits items via `JSON.stringify`, which escapes `"` as `\"` and
+  // `\` as `\\`. The lexer's `parseJsonValue` (src/lexer/RomlLexer.ts
+  // ~line 943) recognised quoted strings via
+  // `trimmed.startsWith('"') && trimmed.endsWith('"')` and returned
+  // `trimmed.slice(1, -1)` — bare slice, NO unescaping. So a single
+  // `"` in an item round-tripped as `\"` (the escape sequence bytes
+  // never got reversed).
+  //
+  // Trace for `{abc: ['a"b', 'c']}` (key `abc` hashes to JSON_STYLE):
+  //   - encoder emits `abc["a\"b","c"]` — 5 bytes inside the first
+  //     quoted item: `a`, `\`, `"`, `b`.
+  //   - lexer slices outer quotes → `a\"b` (4 bytes left intact).
+  //   - round-trip: `a"b` (3 bytes) → `a\"b` (4 bytes). One byte
+  //     leaked from the escape sequence.
+  //
+  // Fix: `parseJsonValue` now uses `JSON.parse(trimmed)` for quoted
+  // strings — the symmetric inverse of `JSON.stringify`. Handles
+  // every JSON-defined escape (`\"`, `\\`, `\n`, `\r`, `\t`, `\b`,
+  // `\f`, `\/`, `\uXXXX`) correctly. Falls back to the literal slice
+  // if JSON.parse throws on pathological hand-written input.
+
+  function roundTrip(input: unknown): unknown {
+    return RomlFile.romlToJson(RomlFile.jsonToRoml(input));
+  }
+
+  // `abc` and `zzz` hash to JSON_STYLE under the current encoder
+  // (`simpleHash(key) % 4`). If the hash distribution shifts, swap
+  // these for any other key whose array emission produces
+  // `key["item1","item2"]` shape.
+
+  describe('items containing `"` (the headline #11 case)', () => {
+    it('round-trips an item with a mid-string `"`', () => {
+      const input = { abc: ['a"b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips an item with a leading `"`', () => {
+      const input = { abc: ['"x', 'y'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips an item with a trailing `"`', () => {
+      const input = { abc: ['x"', 'y'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips an item that is a lone `"`', () => {
+      const input = { abc: ['"', 'x'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips an item with multiple `"`s', () => {
+      const input = { abc: ['"a"b"', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+
+  describe('items containing `\\` (sibling escape mismatch)', () => {
+    it('round-trips an item with a mid-string `\\`', () => {
+      const input = { abc: ['a\\b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips an item with a leading `\\`', () => {
+      const input = { abc: ['\\x', 'y'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips an item that is a lone `\\`', () => {
+      const input = { abc: ['\\', 'x'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips an item with `\\\\` (two backslashes)', () => {
+      const input = { abc: ['a\\\\b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+
+  describe('items combining `"` and `\\`', () => {
+    it('round-trips `a"\\b`', () => {
+      const input = { abc: ['a"\\b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips `\\"`', () => {
+      const input = { abc: ['\\"', 'x'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+
+  describe('items containing JSON-recognised escapes (real control chars)', () => {
+    it('round-trips an item with a real newline', () => {
+      const input = { abc: ['line1\nline2', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips an item with a real tab', () => {
+      const input = { abc: ['col1\tcol2', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+
+  describe('regression: existing JSON_STYLE behaviour still works', () => {
+    it('round-trips plain string items', () => {
+      const input = { abc: ['a', 'b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips mixed-type items (numbers, booleans, strings)', () => {
+      const input = { abc: ['a', 42, true, 'b'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips an empty string item', () => {
+      const input = { abc: ['', 'x'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips a null item', () => {
+      const input = { abc: [null, 'x'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+});

--- a/src/__tests__/RoundTripFuzz.test.ts
+++ b/src/__tests__/RoundTripFuzz.test.ts
@@ -207,10 +207,15 @@ describe('Round-trip property tests (fast-check)', () => {
  *     `parseSpecialCases` and the inline-array branches now use
  *     `^"(.*)"$` so the empty `""` is recognised as an empty
  *     string rather than parsed as the literal 2-char value.)
- * 11. JSON_STYLE primitive array containing a string with `"`: the
- *     encoder uses `JSON.stringify` (which escapes the quote as
- *     `\"`) but the parser slices off the outer quotes without
- *     unescaping, so a single `"` round-trips as `\"`.
+ * 11. (Resolved — `parseJsonValue` now uses `JSON.parse(trimmed)`
+ *     as the symmetric inverse of the encoder's `JSON.stringify`,
+ *     so every JSON-defined escape (`\"`, `\\`, `\n`, `\r`, `\t`,
+ *     `\b`, `\f`, `\/`, `\uXXXX`) is handled correctly. The
+ *     JSON-style item-split also now counts consecutive `\` chars
+ *     to distinguish `\\"` (escaped backslash + closing quote)
+ *     from `\"` (escaped quote inside a still-open string). PIPES
+ *     bare-`"`-in-items is a separate pre-existing limitation;
+ *     see (14).)
  * 12. (Resolved for arrays — the PIPES array emitter now quotes
  *     items containing `|`, and the lexer's PIPES content split is
  *     quote-aware via `splitOutsideQuotes`, so `||` inside a quoted
@@ -227,12 +232,14 @@ describe('Round-trip property tests (fast-check)', () => {
  *     `selectArrayStyle` and keep their existing routing.)
  * 14. Array items containing separator characters that aren't
  *     escaped by the corresponding inline style — `:` (COLON_DELIM),
- *     `>` (BRACKETS, see #9), `"` (JSON_STYLE, see #11). `|` (PIPES)
- *     was here before fix #12 landed; it now round-trips via the
- *     QUOTED-inside-PIPES path and is no longer screened.
- *     The encoder picks the style by hashing the key, so we don't
- *     know which one will be used; conservatively skip any array
- *     whose items contain any of those characters.
+ *     `>` (BRACKETS, see #9), `"` (PIPES — bare-`"` items confuse
+ *     the lexer's `splitOutsideQuotes` because the encoder only
+ *     wraps PIPES items via `isAmbiguousString` (leading/trailing
+ *     `"`) or the local `|` check, not bare-middle `"`). `|`
+ *     (PIPES bytes inside items) was here before #12 landed; `\`
+ *     was here before #11. The encoder picks the style by hashing
+ *     the key, so the screen stays conservative until each
+ *     remaining style+separator combination is fixed.
  * 15. Underscore-bounded line collision: a key that starts/ends with
  *     `_` plus a `__NULL__` / `__EMPTY__` / `__UNDEFINED__` sentinel
  *     value (which themselves start/end with `_`) emits a line like
@@ -269,11 +276,14 @@ function arrayItemsHaveKnownLimitation(arr: unknown[]): boolean {
   }
   // (4) Empty arrays of any depth.
   if (arr.length === 0) return true;
-  // (9, 11, 14) Items containing un-escaped separator chars.
+  // (9, 14) Items containing un-escaped separator chars.
+  // `\` was here before #11 was fixed; it now round-trips in
+  // every array style (BRACKETS/COLON_DELIM emit bare,
+  // JSON_STYLE uses `JSON.parse`, PIPES escapes via QUOTED).
   if (
     arr.some(
       (v) =>
-        typeof v === 'string' && /[:>"\\]/.test(v)
+        typeof v === 'string' && /[:>"]/.test(v)
     )
   ) {
     return true;
@@ -328,15 +338,14 @@ function hasKnownLimitation(input: unknown): boolean {
 
     // (10) resolved; no constraint needed.
 
-    // (11) Array containing a string with `"` or `\` (JSON_STYLE
-    //      escape mismatch — encoder uses JSON.stringify but the
-    //      decoder slices off the outer quotes without unescaping).
-    if (
-      Array.isArray(value) &&
-      value.some((v) => typeof v === 'string' && /["\\]/.test(v))
-    ) {
-      return true;
-    }
+    // (11) Resolved — JSON_STYLE items are now round-tripped via
+    //      `JSON.parse` (the symmetric inverse of the encoder's
+    //      `JSON.stringify`), and the item-split now counts
+    //      consecutive `\` chars to correctly identify escaped vs.
+    //      structural `"`. `"` is still in the (14) screen below
+    //      because PIPES has a separate pre-existing bug where
+    //      bare-`"` items confuse the quote-aware split — not
+    //      relevant to #11 itself.
 
     // (12) Resolved for arrays — see top-level docstring. Scalar
     //      `|`-bearing strings under any key (including COLLECTIONS
@@ -349,9 +358,11 @@ function hasKnownLimitation(input: unknown): boolean {
     //      round-trips cleanly.
 
     // (14) Array items containing un-escaped inline-array separator
-    //      chars: `:`, `>`, `"` (already covered by #11 but restated
-    //      here for completeness with the others). `|` was here
-    //      before #12 was fixed.
+    //      chars: `:` (COLON_DELIM), `>` (BRACKETS, see #9), `"`
+    //      (PIPES — bare `"` confuses `splitOutsideQuotes` because
+    //      the encoder only quotes items containing `|` or other
+    //      `isAmbiguousString` triggers, not bare `"`). `|` was
+    //      here before #12 was fixed; `\` was here before #11.
     if (
       Array.isArray(value) &&
       value.some(

--- a/src/lexer/RomlLexer.ts
+++ b/src/lexer/RomlLexer.ts
@@ -857,35 +857,40 @@ export class RomlLexer {
       const k = extractKey(jsonArrayMatch[1]);
       const arrayContent = jsonArrayMatch[2];
 
-      // Parse JSON-style array items
+      // Parse JSON-style array items. Track a running count of
+      // consecutive `\` bytes immediately before the cursor so we
+      // can decide in O(1) whether the next `"` is escaped (the
+      // naïve "previous byte isn't `\`" check fails on `\\"` —
+      // an escaped backslash followed by a closing quote — the
+      // previous byte is `\` but it's itself part of an escape
+      // pair). `bsRun` is incremented on `\` and reset to 0 on
+      // every other byte; a `"` is unescaped iff `bsRun` is even.
       const items: unknown[] = [];
       let current = '';
       let inQuotes = false;
       let depth = 0;
+      let bsRun = 0;
 
       for (let i = 0; i < arrayContent.length; i++) {
         const char = arrayContent[i];
 
         if (char === '"') {
-          // A `"` toggles `inQuotes` only when it's NOT escaped. The
-          // naïve check "previous byte isn't `\`" fails on `\\"`
-          // (an escaped backslash followed by a closing quote) —
-          // the previous byte is `\` but it's itself part of an
-          // escape pair. Count consecutive preceding backslashes:
-          // if even (including zero), the `"` is unescaped and
-          // toggles; if odd, it's escaped and doesn't.
-          let bsCount = 0;
-          for (let j = i - 1; j >= 0 && arrayContent[j] === '\\'; j--) bsCount++;
-          if (bsCount % 2 === 0) {
+          if (bsRun % 2 === 0) {
             inQuotes = !inQuotes;
           }
           current += char;
+          bsRun = 0;
+        } else if (char === '\\') {
+          current += char;
+          bsRun++;
         } else if (!inQuotes && char === '[') {
           depth++;
           current += char;
+          bsRun = 0;
         } else if (!inQuotes && char === ']') {
           depth--;
           current += char;
+          bsRun = 0;
         } else if (!inQuotes && char === ',' && depth === 0) {
           // End of item
           const trimmed = current.trim();
@@ -893,8 +898,10 @@ export class RomlLexer {
             items.push(this.parseJsonValue(trimmed));
           }
           current = '';
+          bsRun = 0;
         } else {
           current += char;
+          bsRun = 0;
         }
       }
 

--- a/src/lexer/RomlLexer.ts
+++ b/src/lexer/RomlLexer.ts
@@ -501,7 +501,17 @@ export class RomlLexer {
         i++;
         continue;
       }
-      if (char === '\\') {
+      // `\` is an escape introducer ONLY inside a quoted item. The
+      // encoder doubles `\` to `\\` when wrapping a value in
+      // `"..."` (`escapeStringValue`), so inside quotes the next
+      // byte after `\` is part of an escape sequence (`\\`, `\"`,
+      // `\n`, ...) and must not toggle quote state or trigger a
+      // separator split. Outside quotes the encoder emits bytes
+      // verbatim — a bare `\` is just a byte, so we treat it as
+      // such (limitation #11 surfaced this: a PIPES line like
+      // `key||\||false||` was mis-split as one item `\||false`
+      // because the bare `\` consumed the next `|`).
+      if (inQuotes && char === '\\') {
         buffer += char;
         escapeNext = true;
         i++;
@@ -856,8 +866,19 @@ export class RomlLexer {
       for (let i = 0; i < arrayContent.length; i++) {
         const char = arrayContent[i];
 
-        if (char === '"' && (i === 0 || arrayContent[i - 1] !== '\\')) {
-          inQuotes = !inQuotes;
+        if (char === '"') {
+          // A `"` toggles `inQuotes` only when it's NOT escaped. The
+          // naïve check "previous byte isn't `\`" fails on `\\"`
+          // (an escaped backslash followed by a closing quote) —
+          // the previous byte is `\` but it's itself part of an
+          // escape pair. Count consecutive preceding backslashes:
+          // if even (including zero), the `"` is unescaped and
+          // toggles; if odd, it's escaped and doesn't.
+          let bsCount = 0;
+          for (let j = i - 1; j >= 0 && arrayContent[j] === '\\'; j--) bsCount++;
+          if (bsCount % 2 === 0) {
+            inQuotes = !inQuotes;
+          }
           current += char;
         } else if (!inQuotes && char === '[') {
           depth++;
@@ -943,9 +964,21 @@ export class RomlLexer {
   private parseJsonValue(value: string): unknown {
     const trimmed = value.trim();
 
-    // Handle quoted strings - preserve as strings
+    // Handle quoted strings — JSON_STYLE items are emitted via
+    // `JSON.stringify` in the encoder (see RomlConverter ~line 516),
+    // which escapes `\` as `\\`, `"` as `\"`, and control chars as
+    // `\n` / `\r` / `\t` / `\b` / `\f` / `\uXXXX`. `JSON.parse` is
+    // the symmetric inverse. Earlier versions used a bare
+    // `slice(1, -1)`, which left every JSON escape sequence intact
+    // in the returned string (limitation #11). Fall back to the
+    // literal slice if JSON.parse throws on pathological
+    // hand-written input that isn't valid JSON.
     if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
-      return trimmed.slice(1, -1); // Remove quotes and return string
+      try {
+        return JSON.parse(trimmed);
+      } catch {
+        return trimmed.slice(1, -1);
+      }
     }
 
     // Handle special JSON values


### PR DESCRIPTION
## Summary

Limitation #11 in the property-based fuzz: JSON_STYLE array items containing `"` or `\` mangled on round-trip because the encoder uses `JSON.stringify` (escapes `\"`/`\\`) but the lexer's `parseJsonValue` did `trimmed.slice(1, -1)` — bare slice, no unescape.

Three changes, all in `src/lexer/RomlLexer.ts`:

1. **`parseJsonValue`** uses `JSON.parse` for quoted strings (the symmetric inverse of `JSON.stringify`), with a literal-slice fallback for hand-written pathological input. Handles every JSON-defined escape.
2. **JSON-style item-split quote tracking** now counts consecutive preceding `\` chars to distinguish `\\"` (escaped backslash + closing quote — JSON form of a lone backslash item) from `\"` (escaped quote inside an open string). The naïve "previous byte isn't `\`" check was wrong for the former.
3. **`splitOutsideQuotes`** (used by PIPES) only treats `\` as an escape introducer inside `"..."`. The fuzz surfaced a pre-existing bug where bare `\` outside quotes consumed the next `|`, e.g. `key||\||false||` mis-split as one item `\||false`. The encoder only doubles `\` inside quoted-value wrappers, so gating on `inQuotes` matches the encoder's contract.

## Failing test snippet (now passing)

```ts
// src/__tests__/JsonStyleEscapes.test.ts
it('round-trips an item with a mid-string `"`', () => {
  const input = { abc: ['a"b', 'c'] };
  expect(roundTrip(input)).toEqual(input);
});
```

Pre-fix: round-trip returned `{ abc: ['a\\"b', 'c'] }` (one extra byte from the escape sequence leaking through).

## Test plan

- [x] `npm test` — 456 tests pass (17 new in `JsonStyleEscapes.test.ts`, up from 439).
- [x] `npm run lint` — clean.
- [x] `npm run build` — TypeScript clean.
- [x] Pinned fuzz (`seed: 20260507, numRuns: 100`) green after dropping `\` from the array-item screens. `"` stays in the (14) screen for the remaining PIPES bare-`"` pre-existing limitation.
- [x] CLI smoke: `echo '{"abc":["a\"b","c"]}' | node dist/cli.js encode | node dist/cli.js decode` round-trips identically.

BC break: no. Pre-fix encoder output was JSON-valid; the new decoder is strictly more correct on that output. No old document that previously decoded successfully decodes differently — only previously-mangled output is fixed.

Unblocks the remaining `"` portion of #14 (PIPES bare-`"`-in-items) as a small follow-up: the encoder's PIPES item-quoting needs to also flag bare-`"` items (currently only flags `isAmbiguousString` triggers + items containing `|`).

https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV)_