### PR TITLE
fix(encoder): quote PIPES items containing bare `"` (#14 residual)

### DIFF
--- a/src/RomlConverter.ts
+++ b/src/RomlConverter.ts
@@ -464,15 +464,19 @@ export class RomlConverter {
             if (item === null) return '__NULL__';
             if (item === '') return '__EMPTY__';
             if (item === undefined) return '__UNDEFINED__';
-            // Quote ambiguous strings in arrays. `|` is a PIPES-only
-            // collision (the `||` separator), so it's checked here
-            // rather than in `isAmbiguousString` — keeping it local
-            // avoids forcing scalar `|`-bearing values through the
-            // QUOTED escape pipeline (which would expose a separate
-            // unescape-ordering quirk for literal `\r`/`\n`/`\t`).
+            // Quote ambiguous strings in arrays. `|` is the PIPES
+            // `||`-separator collision (fix #12). `"` is the
+            // lexer's quote-tracking collision (fix #14 residual):
+            // the lexer's `splitOutsideQuotes` toggles `inQuotes`
+            // on bare `"` and so an item like `a"b` (odd-count
+            // internal `"`) leaves the splitter mid-quote and
+            // misses the next `||`. Both are PIPES-only collisions,
+            // so they live here rather than in `isAmbiguousString`.
             if (
               typeof item === 'string' &&
-              (this.isAmbiguousString(item) || item.includes('|'))
+              (this.isAmbiguousString(item) ||
+                item.includes('|') ||
+                item.includes('"'))
             ) {
               return `"${escapeStringValue(item)}"`;
             }

--- a/src/__tests__/PipesBareQuoteItems.test.ts
+++ b/src/__tests__/PipesBareQuoteItems.test.ts
@@ -1,0 +1,91 @@
+import { RomlFile } from '../file/RomlFile';
+
+describe('PIPES items containing bare `"` (limitation #14 residual)', () => {
+  // Regression for the PIPES portion of fuzz limitation #14 that
+  // PR #35 (limitation #11) left as a follow-up.
+  //
+  // The PIPES array emitter flagged items containing `|` (PR #32)
+  // and items that `isAmbiguousString` already routed through
+  // QUOTED (e.g. leading/trailing `"`). But a `"` in the middle
+  // of an item passed through unquoted, and the lexer's
+  // `splitOutsideQuotes` would then toggle `inQuotes` mid-item:
+  //
+  //   {x: ['a"b', 'c']} -> x||a"b||c|| -> {x: 'a"b||c'}
+  //
+  // The lexer reads the first `"` of `a"b` as a quote-open,
+  // continues in-quotes past the `||` separator, and never closes
+  // because the item has no second `"`. Result: a single-string
+  // scalar containing the would-be-separator bytes.
+  //
+  // Even-count internal `"`s happened to round-trip because the
+  // state ends balanced (`a"b"c` → in, out, end), so this bug
+  // surfaces specifically with odd-count bare-`"` items.
+  //
+  // Fix: extend the PIPES item-quoting check in `RomlConverter.ts`
+  // to also flag items containing any `"`. Routes them through
+  // the existing QUOTED-inside-PIPES path, which uses
+  // `escapeStringValue` to escape the embedded quotes.
+
+  function roundTrip(input: unknown): unknown {
+    return RomlFile.romlToJson(RomlFile.jsonToRoml(input));
+  }
+
+  describe('items with odd-count internal quotes (previously broken)', () => {
+    it('round-trips a single mid-string `"`', () => {
+      const input = { x: ['a"b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips three internal quotes', () => {
+      const input = { x: ['a"b"c"d', 'e'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips a top-level array root with bare-`"` item', () => {
+      const input = ['a"b', 'c'];
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips a `"` next to `|` in an item', () => {
+      const input = { x: ['a"|b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips an item with `"` and embedded `\\`', () => {
+      const input = { x: ['a"\\b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+
+  describe('regression: items that already worked still work', () => {
+    it('round-trips leading-`"` items (`isAmbiguousString` flagged)', () => {
+      const input = { x: ['"x', 'y'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips trailing-`"` items', () => {
+      const input = { x: ['x"', 'y'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips lone-`"` items', () => {
+      const input = { x: ['"', 'y'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips even-count internal quotes (state was balanced)', () => {
+      const input = { x: ['a"b"c', 'd'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips plain items (no quotes)', () => {
+      const input = { x: ['a', 'b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips items containing `|` (#12 fix path)', () => {
+      const input = { x: ['a|b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+});

--- a/src/__tests__/RoundTripFuzz.test.ts
+++ b/src/__tests__/RoundTripFuzz.test.ts
@@ -231,15 +231,16 @@ describe('Round-trip property tests (fast-check)', () => {
  *     KV style. Array values under those keys still go through
  *     `selectArrayStyle` and keep their existing routing.)
  * 14. Array items containing separator characters that aren't
- *     escaped by the corresponding inline style — `:` (COLON_DELIM),
- *     `>` (BRACKETS, see #9), `"` (PIPES — bare-`"` items confuse
- *     the lexer's `splitOutsideQuotes` because the encoder only
- *     wraps PIPES items via `isAmbiguousString` (leading/trailing
- *     `"`) or the local `|` check, not bare-middle `"`). `|`
- *     (PIPES bytes inside items) was here before #12 landed; `\`
- *     was here before #11. The encoder picks the style by hashing
- *     the key, so the screen stays conservative until each
- *     remaining style+separator combination is fixed.
+ *     escaped by the corresponding inline style — currently only
+ *     `:` (COLON_DELIM) and `>` (BRACKETS, see #9) remain. `|`
+ *     was resolved by #12 (QUOTED-inside-PIPES). `\` was resolved
+ *     by #11 (JSON.parse for JSON_STYLE + escape-state gating in
+ *     `splitOutsideQuotes`). `"` was resolved by extending the
+ *     PIPES item-quoting check to also flag bare-`"` items (the
+ *     #14-residual fix on the heels of #11). The encoder picks
+ *     the style by hashing the key, so the screen stays
+ *     conservative until each remaining style+separator
+ *     combination is fixed.
  * 15. Underscore-bounded line collision: a key that starts/ends with
  *     `_` plus a `__NULL__` / `__EMPTY__` / `__UNDEFINED__` sentinel
  *     value (which themselves start/end with `_`) emits a line like
@@ -277,13 +278,14 @@ function arrayItemsHaveKnownLimitation(arr: unknown[]): boolean {
   // (4) Empty arrays of any depth.
   if (arr.length === 0) return true;
   // (9, 14) Items containing un-escaped separator chars.
-  // `\` was here before #11 was fixed; it now round-trips in
+  // `\` was here before #11 was fixed; `"` was here before the
+  // #14-residual PIPES bare-`"` fix. Both now round-trip in
   // every array style (BRACKETS/COLON_DELIM emit bare,
-  // JSON_STYLE uses `JSON.parse`, PIPES escapes via QUOTED).
+  // JSON_STYLE uses `JSON.parse`, PIPES routes via QUOTED).
   if (
     arr.some(
       (v) =>
-        typeof v === 'string' && /[:>"]/.test(v)
+        typeof v === 'string' && /[:>]/.test(v)
     )
   ) {
     return true;
@@ -358,16 +360,15 @@ function hasKnownLimitation(input: unknown): boolean {
     //      round-trips cleanly.
 
     // (14) Array items containing un-escaped inline-array separator
-    //      chars: `:` (COLON_DELIM), `>` (BRACKETS, see #9), `"`
-    //      (PIPES — bare `"` confuses `splitOutsideQuotes` because
-    //      the encoder only quotes items containing `|` or other
-    //      `isAmbiguousString` triggers, not bare `"`). `|` was
-    //      here before #12 was fixed; `\` was here before #11.
+    //      chars that remain open: `:` (COLON_DELIM) and `>`
+    //      (BRACKETS, see #9). `|` was here before #12 was fixed;
+    //      `\` was here before #11; `"` was here before the
+    //      #14-residual PIPES bare-`"` fix.
     if (
       Array.isArray(value) &&
       value.some(
         (v) =>
-          typeof v === 'string' && /[:>"]/.test(v)
+          typeof v === 'string' && /[:>]/.test(v)
       )
     ) {
       return true;


### PR DESCRIPTION
## Summary

The PIPES portion of limitation #14, left as a follow-up by PR #35 (limitation #11). PIPES items with an odd-count bare-middle `"` (e.g. `a"b`) emitted unquoted and the lexer's `splitOutsideQuotes` toggled `inQuotes` mid-item, missing the next `||` separator.

Trace pre-fix:
```
{x: ['a"b', 'c']} -> x||a"b||c|| -> {x: 'a"b||c'}
```

Even-count internal `"`s round-tripped because the state ended balanced (`a"b"c` → in, out, end). Odd-count broke.

Fix is one line in `src/RomlConverter.ts`: the PIPES array emitter's per-item quote check now flags items containing any `"`, routing them through the existing QUOTED-inside-PIPES path (`escapeStringValue` handles the embedded escape).

## Failing test (now passing)

```ts
it('round-trips a single mid-string `"`', () => {
  const input = { x: ['a"b', 'c'] };
  expect(roundTrip(input)).toEqual(input);
});
```

## Test plan

- [x] `npm test` — 467 tests pass (11 new in `PipesBareQuoteItems.test.ts`, up from 456).
- [x] `npm run lint` — clean.
- [x] `npm run build` — TypeScript clean.
- [x] Pinned fuzz (`seed: 20260507, numRuns: 100`) green after dropping `"` from both `arrayItemsHaveKnownLimitation` and the (14) screen.
- [x] Smoke: `{x: ['a"b', 'c']}` round-trips identically.

BC break: no. Pre-fix output for bare-`"`-bearing PIPES items was ambiguous/lossy (the fuzz screen kept those out of the test surface). New output is byte-compatible with the existing lexer for all `"`-free input.

After this PR, only `:` and `>` remain in the item-screen regex — both correspond to specific open limitations (#9 BRACKETS `>` and the COLON_DELIM `:` portion of #14).

https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV)_