### PR TITLE
fix(format): quote-aware BRACKETS item parsing + `>`/`<` escape (#9)

### DIFF
--- a/src/RomlConverter.ts
+++ b/src/RomlConverter.ts
@@ -497,15 +497,19 @@ export class RomlConverter {
             // Quote ambiguous strings in arrays. `>` and `<` are
             // the BRACKETS structural delimiters — a bare `>` in
             // an item terminates the item early in the lexer, and
-            // `<` can interact with the start marker. Route any
-            // item containing either through the QUOTED-inside-
-            // BRACKETS path so the lexer's quote-aware walker
-            // treats them as one element (limitation #9).
+            // `<` can interact with the start marker. `"` is the
+            // quote-tracking delimiter the lexer walker uses, so
+            // a bare middle-`"` (not caught by `isAmbiguousString`)
+            // would put the walker into `inQuotes` and prevent the
+            // closing `>` from ending the item. Route any item
+            // containing any of these through the QUOTED-inside-
+            // BRACKETS path (limitation #9).
             if (
               typeof item === 'string' &&
               (this.isAmbiguousString(item) ||
                 item.includes('>') ||
-                item.includes('<'))
+                item.includes('<') ||
+                item.includes('"'))
             ) {
               return `<"${escapeStringValue(item)}">`;
             }

--- a/src/RomlConverter.ts
+++ b/src/RomlConverter.ts
@@ -494,8 +494,19 @@ export class RomlConverter {
             if (item === null) return '<__NULL__>';
             if (item === '') return '<__EMPTY__>';
             if (item === undefined) return '<__UNDEFINED__>';
-            // Quote ambiguous strings in arrays
-            if (typeof item === 'string' && this.isAmbiguousString(item)) {
+            // Quote ambiguous strings in arrays. `>` and `<` are
+            // the BRACKETS structural delimiters — a bare `>` in
+            // an item terminates the item early in the lexer, and
+            // `<` can interact with the start marker. Route any
+            // item containing either through the QUOTED-inside-
+            // BRACKETS path so the lexer's quote-aware walker
+            // treats them as one element (limitation #9).
+            if (
+              typeof item === 'string' &&
+              (this.isAmbiguousString(item) ||
+                item.includes('>') ||
+                item.includes('<'))
+            ) {
               return `<"${escapeStringValue(item)}">`;
             }
             return `<${item}>`;

--- a/src/__tests__/BracketsGtLtItems.test.ts
+++ b/src/__tests__/BracketsGtLtItems.test.ts
@@ -79,6 +79,29 @@ describe('BRACKETS items containing `>` or `<` (limitation #9)', () => {
     });
   });
 
+  describe('items with bare `"` (Copilot review on this PR)', () => {
+    // The lexer walker tracks quote state, so a bare middle-`"`
+    // in an item (not caught by `isAmbiguousString`, which only
+    // flags leading/trailing `"`) would put the walker into
+    // `inQuotes` and prevent the closing `>` from ending the
+    // item. Encoder must quote any `"`-bearing item.
+
+    it('round-trips a mid-string `"`', () => {
+      const input = { elements: ['a"b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips multiple `"`s in one item', () => {
+      const input = { elements: ['a"b"c', 'd'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips a lone-`"` item (also worked pre-fix via leading/trailing check)', () => {
+      const input = { elements: ['"', 'y'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+
   describe('escape composition: `>` combined with other tricky bytes', () => {
     it('round-trips `>` plus `"`', () => {
       const input = { elements: ['a">b', 'c'] };

--- a/src/__tests__/BracketsGtLtItems.test.ts
+++ b/src/__tests__/BracketsGtLtItems.test.ts
@@ -1,0 +1,127 @@
+import { RomlFile } from '../file/RomlFile';
+
+describe('BRACKETS items containing `>` or `<` (limitation #9)', () => {
+  // Regression for fuzz limitation #9.
+  //
+  // BRACKETS emits items as `<value>`, so a `>` byte inside the
+  // item content terminates the item early. The lexer used
+  // `<([^>]*)>` (matchAll), structurally unable to represent
+  // any `>` inside an item:
+  //
+  //   {elements: ['a>b', 'c']} -> elements<a>b><c> -> {elements: ['a','c']}
+  //
+  // `<` happened to round-trip because the regex `[^>]*` doesn't
+  // exclude it, but a leading `>` collapsed entire items because
+  // the empty match between consecutive `>`s got filtered out as
+  // an empty string.
+  //
+  // Fix has two halves:
+  //   - encoder: flag `>` and `<` in items so they route through
+  //     the existing `<"escaped">` (QUOTED-inside-BRACKETS) path.
+  //   - lexer: replace the regex extraction with a quote-aware
+  //     walker that treats `>` as an item terminator only outside
+  //     a `"..."` region within the item. Mirrors the
+  //     `splitOutsideQuotes` pattern from #12 but for the
+  //     between-marker shape rather than separator-split.
+
+  function roundTrip(input: unknown): unknown {
+    return RomlFile.romlToJson(RomlFile.jsonToRoml(input));
+  }
+
+  describe('items with `>` (the headline #9 case)', () => {
+    it('round-trips a mid-string `>`', () => {
+      const input = { elements: ['a>b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips a leading `>`', () => {
+      const input = { elements: ['>x', 'y'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips a trailing `>`', () => {
+      const input = { elements: ['x>', 'y'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips a lone `>`', () => {
+      const input = { elements: ['>', 'y'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips multiple `>`s in one item', () => {
+      const input = { elements: ['a>b>c', 'd'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+
+  describe('items with `<`', () => {
+    it('round-trips a mid-string `<` (no regression)', () => {
+      const input = { elements: ['a<b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips a leading `<`', () => {
+      const input = { elements: ['<x', 'y'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+
+  describe('items combining `<` and `>`', () => {
+    it('round-trips an item with `<>` inside', () => {
+      const input = { elements: ['a<>b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips an item with HTML-like content', () => {
+      const input = { elements: ['<tag>content</tag>', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+
+  describe('escape composition: `>` combined with other tricky bytes', () => {
+    it('round-trips `>` plus `"`', () => {
+      const input = { elements: ['a">b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips `>` plus `\\`', () => {
+      const input = { elements: ['a>\\b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips `>` plus `|`', () => {
+      const input = { elements: ['a>|b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+
+  describe('top-level array roots with `>` items', () => {
+    it('round-trips an array root with a `>`-bearing item', () => {
+      const input = ['a>b', 'c'];
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+
+  describe('regression: existing BRACKETS round-trips still work', () => {
+    it('round-trips plain string items', () => {
+      const input = { elements: ['a', 'b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips a single-element array (uses the `<>` arity marker)', () => {
+      const input = { elements: ['only'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips empty-string items via __EMPTY__', () => {
+      const input = { elements: ['a', '', 'b'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips null items via __NULL__', () => {
+      const input = { elements: ['a', null, 'b'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+});

--- a/src/__tests__/RoundTripFuzz.test.ts
+++ b/src/__tests__/RoundTripFuzz.test.ts
@@ -198,11 +198,12 @@ describe('Round-trip property tests (fast-check)', () => {
  *  8. (Resolved — `isSpecialValue` is checked ahead of the type-
  *     specific branches, so null / undefined / empty-string sentinels
  *     always pick a non-quoting style regardless of the key shape.)
- *  9. BRACKETS-style primitive array containing a string item with
- *     `>` in it: the encoder doesn't escape `>` inside `<value>`
- *     items, so the lexer's `<([^>]*)>` regex splits at the wrong
- *     `>`. We don't know which array style the encoder will pick (it
- *     hashes the key), so any string-array containing `>` is skipped.
+ *  9. (Resolved — BRACKETS items containing `>` or `<` now route
+ *     through the QUOTED-inside-BRACKETS path
+ *     (`<"escaped">`), and the lexer parses items with a
+ *     quote-aware walker that mirrors `splitOutsideQuotes`
+ *     instead of the structurally-limited `<([^>]*)>` regex,
+ *     so `>` inside a quoted item no longer terminates it.)
  * 10. (Resolved — the value-quoted regex sites in
  *     `parseSpecialCases` and the inline-array branches now use
  *     `^"(.*)"$` so the empty `""` is recognised as an empty
@@ -231,16 +232,12 @@ describe('Round-trip property tests (fast-check)', () => {
  *     KV style. Array values under those keys still go through
  *     `selectArrayStyle` and keep their existing routing.)
  * 14. Array items containing separator characters that aren't
- *     escaped by the corresponding inline style — currently only
- *     `:` (COLON_DELIM) and `>` (BRACKETS, see #9) remain. `|`
- *     was resolved by #12 (QUOTED-inside-PIPES). `\` was resolved
- *     by #11 (JSON.parse for JSON_STYLE + escape-state gating in
- *     `splitOutsideQuotes`). `"` was resolved by extending the
- *     PIPES item-quoting check to also flag bare-`"` items (the
- *     #14-residual fix on the heels of #11). The encoder picks
- *     the style by hashing the key, so the screen stays
- *     conservative until each remaining style+separator
- *     combination is fixed.
+ *     escaped by the corresponding inline style — only `:`
+ *     (COLON_DELIM) remains. `|` was resolved by #12,
+ *     `\` by #11, `"` by the #14-residual PIPES fix, `>` by #9.
+ *     The encoder picks the style by hashing the key, so the
+ *     screen stays conservative until the COLON_DELIM `:` case
+ *     is fixed (last item on the inline-array escape ledger).
  * 15. Underscore-bounded line collision: a key that starts/ends with
  *     `_` plus a `__NULL__` / `__EMPTY__` / `__UNDEFINED__` sentinel
  *     value (which themselves start/end with `_`) emits a line like
@@ -277,15 +274,13 @@ function arrayItemsHaveKnownLimitation(arr: unknown[]): boolean {
   }
   // (4) Empty arrays of any depth.
   if (arr.length === 0) return true;
-  // (9, 14) Items containing un-escaped separator chars.
-  // `\` was here before #11 was fixed; `"` was here before the
-  // #14-residual PIPES bare-`"` fix. Both now round-trip in
-  // every array style (BRACKETS/COLON_DELIM emit bare,
-  // JSON_STYLE uses `JSON.parse`, PIPES routes via QUOTED).
+  // (14) Items containing un-escaped separator chars. Only `:`
+  // (COLON_DELIM) remains. `\` was resolved by #11, `"` by the
+  // #14-residual PIPES bare-`"` fix, `>` by #9.
   if (
     arr.some(
       (v) =>
-        typeof v === 'string' && /[:>]/.test(v)
+        typeof v === 'string' && /[:]/.test(v)
     )
   ) {
     return true;
@@ -330,13 +325,10 @@ function hasKnownLimitation(input: unknown): boolean {
 
     // (7) and (8) resolved; no constraints needed.
 
-    // (9) Array containing a string with `>` (BRACKETS-style escape).
-    if (
-      Array.isArray(value) &&
-      value.some((v) => typeof v === 'string' && v.includes('>'))
-    ) {
-      return true;
-    }
+    // (9) Resolved — BRACKETS items now route `>`/`<`-bearing
+    //      strings through the QUOTED-inside-BRACKETS path, and
+    //      the lexer parses items with a quote-aware walker
+    //      instead of `<([^>]*)>`. See top-level docstring entry.
 
     // (10) resolved; no constraint needed.
 
@@ -360,15 +352,14 @@ function hasKnownLimitation(input: unknown): boolean {
     //      round-trips cleanly.
 
     // (14) Array items containing un-escaped inline-array separator
-    //      chars that remain open: `:` (COLON_DELIM) and `>`
-    //      (BRACKETS, see #9). `|` was here before #12 was fixed;
-    //      `\` was here before #11; `"` was here before the
-    //      #14-residual PIPES bare-`"` fix.
+    //      chars. Only `:` (COLON_DELIM) remains. `|` was resolved
+    //      by #12, `\` by #11, `"` by the #14-residual PIPES fix,
+    //      `>` by #9.
     if (
       Array.isArray(value) &&
       value.some(
         (v) =>
-          typeof v === 'string' && /[:>]/.test(v)
+          typeof v === 'string' && /[:]/.test(v)
       )
     ) {
       return true;

--- a/src/lexer/RomlLexer.ts
+++ b/src/lexer/RomlLexer.ts
@@ -773,24 +773,78 @@ export class RomlLexer {
       }
     }
 
-    // Parse multiple brackets (arrays): key<item1><item2>
+    // Parse multiple brackets (arrays): key<item1><item2>...
+    //
+    // The previous extraction used `matchAll(/<([^>]*)>/g)`, which
+    // was structurally unable to represent `>` inside an item.
+    // Walk the content char-by-char instead, tracking item-state
+    // and quote-state so `<"a>b">` is one item rather than two
+    // (limitation #9). The `\` inside a quoted item is an escape
+    // introducer (mirrors `splitOutsideQuotes`).
+    //
+    // Use `findSeparatorOutsideQuotes` for the key/items boundary
+    // — a quoted key containing `<` (e.g. `"<-"<false><null>`) has
+    // its first `<` inside the quoted region, which is part of
+    // the key, not a structural item-start marker.
     const multiBracketMatch = line.match(/^(.+?)(<.+>)+$/);
     if (multiBracketMatch && line.includes('><')) {
-      const k = extractKey(multiBracketMatch[1]);
-      const items = [...line.matchAll(/<([^>]*)>/g)]
-        .map((match) => match[1])
-        .filter((itemValue) => itemValue !== '') // Filter out empty brackets
+      const firstBracket = this.findSeparatorOutsideQuotes(line, '<');
+      if (firstBracket <= 0) {
+        // Either no `<` outside quotes, or the line starts with one
+        // (no key bytes) — neither is the multi-bracket shape we
+        // handle here. Fall through to other parsers.
+        return null;
+      }
+      const k = extractKey(line.slice(0, firstBracket));
+      const content = line.slice(firstBracket); // starts with `<`, ends with `>`
+
+      const items: string[] = [];
+      let buffer = '';
+      let inItem = false;
+      let inQuotes = false;
+      let escapeNext = false;
+      for (let i = 0; i < content.length; i++) {
+        const c = content[i];
+        if (!inItem) {
+          if (c === '<') inItem = true;
+          continue;
+        }
+        if (escapeNext) {
+          buffer += c;
+          escapeNext = false;
+          continue;
+        }
+        if (inQuotes && c === '\\') {
+          buffer += c;
+          escapeNext = true;
+          continue;
+        }
+        if (c === '"') {
+          buffer += c;
+          inQuotes = !inQuotes;
+          continue;
+        }
+        if (!inQuotes && c === '>') {
+          items.push(buffer);
+          buffer = '';
+          inItem = false;
+          continue;
+        }
+        buffer += c;
+      }
+
+      const processed = items
+        .filter((itemValue) => itemValue !== '') // empty brackets are arity markers
         .map((itemValue) => {
           // Check if item is quoted. `(.*)` so the empty quoted
           // form `""` is recognised as an empty string.
           const quotedMatch = itemValue.match(/^"(.*)"$/);
           if (quotedMatch) {
-            // Preserve quoted values as strings and unescape
             return unescapeStringValue(quotedMatch[1]);
           }
           return this.parseSpecialValue(itemValue);
         });
-      return [k.key, items, 'BRACKETS', k.wasQuoted, k.hasPrimePrefix];
+      return [k.key, processed, 'BRACKETS', k.wasQuoted, k.hasPrimePrefix];
     }
 
     // Single-bracket parsing has moved to `analyzeLineStructure`'s
@@ -853,9 +907,18 @@ export class RomlLexer {
 
     // Parse JSON-style arrays: key["item1",7,"true",true]
     const jsonArrayMatch = line.match(/^(.+?)\[(.+)\]$/);
-    if (jsonArrayMatch && jsonArrayMatch[2].includes(',')) {
-      const k = extractKey(jsonArrayMatch[1]);
-      const arrayContent = jsonArrayMatch[2];
+    if (jsonArrayMatch && jsonArrayMatch[2].includes(',') && line.endsWith(']')) {
+      // Find the key/items boundary at the first `[` OUTSIDE the
+      // quoted-key region. A bare lazy `.+?` finds the first `[`
+      // anywhere, which mis-splits a quoted key containing `[`
+      // (e.g. `"7[J"[null,""]` — the regex captures `"7` as the
+      // key and `J"[null,""` as the array). Same pattern as the
+      // BRACKETS key-boundary fix in this PR.
+      const openIdx = this.findSeparatorOutsideQuotes(line, '[');
+      if (openIdx <= 0) return null;
+      const k = extractKey(line.slice(0, openIdx));
+      const arrayContent = line.slice(openIdx + 1, -1);
+      if (!arrayContent.includes(',')) return null;
 
       // Parse JSON-style array items. Track a running count of
       // consecutive `\` bytes immediately before the cursor so we


### PR DESCRIPTION
## Summary

Limitation #9: BRACKETS-style array items containing `>` mangled on round-trip because the encoder didn't quote them and the lexer's `<([^>]*)>` regex was structurally unable to represent `>` inside an item.

```
{elements: ['a>b', 'c']} -> elements<a>b><c> -> {elements: ['a','c']}
```

Three changes:

1. **Encoder** (`src/RomlConverter.ts` BRACKETS emitter): flag items containing `>` or `<` so they route through the existing `<"escaped">` path. Same pattern as PIPES `|` (PR #32) and `"` (PR #36).
2. **Lexer** (BRACKETS branch): replace `matchAll(/<([^>]*)>/g)` with a quote-aware walker. `>` terminates an item only outside a `"…"` region, so `<"a>b">` is one element.
3. **Companion fix surfaced by the fuzz**: dropping `>` from the screen produced a counterexample `{"7[J": [null,""]}`. The BRACKETS walker uses `findSeparatorOutsideQuotes` for the key/items boundary so a quoted key containing `<` is handled correctly. Same family of bug existed in the JSON_STYLE branch (`^(.+?)\[(.+)\]$` mis-split for `"7[J"[null,""]`). Fixed symmetrically.

## Failing test (now passing)

```ts
it('round-trips a mid-string `>`', () => {
  const input = { elements: ['a>b', 'c'] };
  expect(roundTrip(input)).toEqual(input);
});
```

## Test plan

- [x] `npm test` — 484 tests pass (17 new in `BracketsGtLtItems.test.ts`, up from 467).
- [x] `npm run lint` — clean.
- [x] `npm run build` — TypeScript clean.
- [x] Pinned fuzz (`seed: 20260507, numRuns: 100`) green after dropping `>` from the (9)/(14) screens. Only `:` (COLON_DELIM) remains.
- [x] CLI smoke: `{elements: ['a>b', 'c']}`, `{"<-": [false, null]}`, `{"7[J": [null, ""]}` all round-trip identically.

BC break: no. Pre-fix output for `>`-bearing BRACKETS items was already lossy (screened by the fuzz). New encoder output is byte-compatible with the existing lexer for all `>`/`<`-free items.

After this PR, only `:` (COLON_DELIM) remains in the item-screen regex — the last single-char inline-array escape ledger item.

https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV)_