### PR TITLE
fix(format): quote-aware COLON_DELIM items + `:` escape (#14 residual)

### DIFF
--- a/src/RomlConverter.ts
+++ b/src/RomlConverter.ts
@@ -547,8 +547,20 @@ export class RomlConverter {
           if (item === null) return '__NULL__';
           if (item === '') return '__EMPTY__';
           if (item === undefined) return '__UNDEFINED__';
-          // Quote ambiguous strings in arrays
-          if (typeof item === 'string' && this.isAmbiguousString(item)) {
+          // Quote ambiguous strings in arrays. `:` is the
+          // COLON_DELIM separator; same shape as the PIPES `|`
+          // (#32), PIPES `"` (#36), and BRACKETS `>`/`<` (#37)
+          // checks — route any `:`-bearing item through the
+          // QUOTED-inside-COLON path so the lexer's quote-aware
+          // split treats it as one element (limitation #14
+          // residual). `"` is also flagged for the same
+          // splitter-quote-tracking reason as PIPES (#36).
+          if (
+            typeof item === 'string' &&
+            (this.isAmbiguousString(item) ||
+              item.includes(':') ||
+              item.includes('"'))
+          ) {
             return `"${escapeStringValue(item)}"`;
           }
           return String(item);

--- a/src/__tests__/ColonDelimColonItems.test.ts
+++ b/src/__tests__/ColonDelimColonItems.test.ts
@@ -1,0 +1,97 @@
+import { RomlFile } from '../file/RomlFile';
+
+describe('COLON_DELIM items containing `:` (limitation #14 residual)', () => {
+  // Regression for the last `:` portion of fuzz limitation #14.
+  //
+  // COLON_DELIM emits items as `key:a:b:c` (single-`:` separator).
+  // The encoder didn't quote items containing `:`, and the lexer's
+  // `colonRemainder.split(':')` was a plain split:
+  //
+  //   {id: ['a:b', 'c']} -> id:a:b:c -> {id: ['a','b','c']}
+  //
+  // Same family as the PIPES `|` fix (#32), PIPES `"` fix (#36),
+  // and BRACKETS `>`/`<` fix (#37): the inline-array style needs
+  // both halves to round-trip — encoder routes `:`-bearing items
+  // through the QUOTED-inside-COLON path, lexer's split becomes
+  // quote-aware via `splitOutsideQuotes`.
+
+  function roundTrip(input: unknown): unknown {
+    return RomlFile.romlToJson(RomlFile.jsonToRoml(input));
+  }
+
+  // `id` is a TECHNICAL semantic key that gets routed to
+  // COLON_DELIM via `selectArrayStyle`. If the hash distribution
+  // shifts, swap for another key whose array emission produces
+  // `key:item1:item2` shape.
+
+  describe('items containing `:` (the headline case)', () => {
+    it('round-trips a mid-string `:`', () => {
+      const input = { id: ['a:b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips a leading `:`', () => {
+      const input = { id: [':x', 'y'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips a trailing `:`', () => {
+      const input = { id: ['x:', 'y'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips a lone `:`', () => {
+      const input = { id: [':', 'y'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips multiple `:`s in one item', () => {
+      const input = { id: ['a:b:c', 'd'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips `::` (consecutive `:`s) in one item', () => {
+      const input = { id: ['a::b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+
+  describe('escape composition: `:` combined with other tricky bytes', () => {
+    it('round-trips `:` plus `"`', () => {
+      const input = { id: ['a":b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips `:` plus `\\`', () => {
+      const input = { id: ['a:\\b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips `:` plus `|`', () => {
+      const input = { id: ['a:|b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+
+  describe('regression: existing COLON_DELIM round-trips still work', () => {
+    it('round-trips plain string items', () => {
+      const input = { id: ['a', 'b', 'c'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips numeric-string items', () => {
+      const input = { id: ['1', '2', '3'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips an empty-string item via __EMPTY__', () => {
+      const input = { id: ['a', '', 'b'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('round-trips null items via __NULL__', () => {
+      const input = { id: ['a', null, 'b'] };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+});

--- a/src/__tests__/RoundTripFuzz.test.ts
+++ b/src/__tests__/RoundTripFuzz.test.ts
@@ -231,13 +231,13 @@ describe('Round-trip property tests (fast-check)', () => {
  *     through to the value-type branches and pick a non-PIPES
  *     KV style. Array values under those keys still go through
  *     `selectArrayStyle` and keep their existing routing.)
- * 14. Array items containing separator characters that aren't
- *     escaped by the corresponding inline style — only `:`
- *     (COLON_DELIM) remains. `|` was resolved by #12,
- *     `\` by #11, `"` by the #14-residual PIPES fix, `>` by #9.
- *     The encoder picks the style by hashing the key, so the
- *     screen stays conservative until the COLON_DELIM `:` case
- *     is fixed (last item on the inline-array escape ledger).
+ * 14. (Resolved — every inline-array separator char now round-
+ *     trips through its style's QUOTED escape pipeline plus a
+ *     quote-aware lexer split. `|` (PIPES, #12+#36),
+ *     `\`/`"` (JSON_STYLE, #11), `"` (PIPES, #36; BRACKETS, #37;
+ *     COLON_DELIM, this PR), `>`/`<` (BRACKETS, #9), `:`
+ *     (COLON_DELIM, this PR). The inline-array escape ledger is
+ *     empty.)
  * 15. Underscore-bounded line collision: a key that starts/ends with
  *     `_` plus a `__NULL__` / `__EMPTY__` / `__UNDEFINED__` sentinel
  *     value (which themselves start/end with `_`) emits a line like
@@ -274,17 +274,10 @@ function arrayItemsHaveKnownLimitation(arr: unknown[]): boolean {
   }
   // (4) Empty arrays of any depth.
   if (arr.length === 0) return true;
-  // (14) Items containing un-escaped separator chars. Only `:`
-  // (COLON_DELIM) remains. `\` was resolved by #11, `"` by the
-  // #14-residual PIPES bare-`"` fix, `>` by #9.
-  if (
-    arr.some(
-      (v) =>
-        typeof v === 'string' && /[:]/.test(v)
-    )
-  ) {
-    return true;
-  }
+  // (14) Resolved — every inline-array separator-char now
+  // round-trips: `|` (#12, #36), `\` (#11), `"` (#36 PIPES,
+  // #37 BRACKETS, this PR for COLON_DELIM), `>`/`<` (#9), `:`
+  // (this PR). The ledger is empty.
   return false;
 }
 
@@ -351,19 +344,10 @@ function hasKnownLimitation(input: unknown): boolean {
     //      under a COLLECTIONS key picks a non-PIPES KV style and
     //      round-trips cleanly.
 
-    // (14) Array items containing un-escaped inline-array separator
-    //      chars. Only `:` (COLON_DELIM) remains. `|` was resolved
-    //      by #12, `\` by #11, `"` by the #14-residual PIPES fix,
-    //      `>` by #9.
-    if (
-      Array.isArray(value) &&
-      value.some(
-        (v) =>
-          typeof v === 'string' && /[:]/.test(v)
-      )
-    ) {
-      return true;
-    }
+    // (14) Resolved — see top-level docstring. Every
+    //      inline-array separator-char now round-trips through
+    //      its style's QUOTED escape pipeline + quote-aware
+    //      lexer split.
 
     // (15) Underscore-bounded key + sentinel-value collision.
     if (

--- a/src/lexer/RomlLexer.ts
+++ b/src/lexer/RomlLexer.ts
@@ -1001,7 +1001,11 @@ export class RomlLexer {
       }
       if (!hasEarlierSeparator) {
         const k = extractKey(line.slice(0, firstColonPos));
-        const items = colonRemainder.split(':').map((item) => {
+        // Quote-aware split (limitation #14 residual): a
+        // `:`-bearing item is emitted by the encoder as `"…"` so
+        // its bytes survive the round-trip; plain split on `:`
+        // would shred items containing `:` like `"a:b"` into two.
+        const items = this.splitOutsideQuotes(colonRemainder, ':').map((item) => {
           // Check if item is quoted (can be empty)
           const quotedMatch = item.match(/^"(.*)"$/);
           if (quotedMatch) {


### PR DESCRIPTION
## Summary

The last `:` portion of fuzz limitation #14. COLON_DELIM emitted array items joined by `:` without quoting any `:`-bearing item, and the lexer's `colonRemainder.split(':')` was a plain split:

```
{id: ['a:b', 'c']} -> id:a:b:c -> {id: ['a','b','c']}
```

Same shape as PIPES `|` (#32), PIPES `"` (#36), BRACKETS `>`/`<` (#37). Both halves:

1. **Encoder** (COLON_DELIM emitter): flag items containing `:` (and `"`, mirroring the PIPES bare-`"` fix) so they route through the QUOTED-inside-COLON path.
2. **Lexer** (COLON_DELIM branch): replace `colonRemainder.split(':')` with `splitOutsideQuotes`.

## Test plan

- [x] `npm test` — 500 tests pass (13 new), up from 487.
- [x] `npm run lint` — clean.
- [x] `npm run build` — TypeScript clean.
- [x] Pinned fuzz (`seed: 20260507`) green after dropping `:` from screens. **The inline-array escape ledger is now empty.**

After this PR, only #3 (single-element primitive arrays) and #4 (empty arrays in non-PIPES) remain — both architectural.

https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV)_