### PR TITLE
fix(format): force PIPES for empty arrays + companion bugs (#4)

### DIFF
--- a/src/RomlConverter.ts
+++ b/src/RomlConverter.ts
@@ -447,8 +447,18 @@ export class RomlConverter {
       };
     }
 
-    // For primitive arrays, they take only one line
-    const arrayStyle = this.selectArrayStyle(key, context);
+    // For primitive arrays, they take only one line.
+    //
+    // Empty arrays force PIPES regardless of hash: only PIPES has
+    // a recoverable empty-form (`key||||`) that the lexer
+    // round-trips as `[]`. BRACKETS would emit a bare `key`, the
+    // JSON_STYLE `key[]` shape needs a `,` in content to match,
+    // and COLON_DELIM's `key:` shape is indistinguishable from a
+    // scalar KV-COLON with empty value. Same shortcut pattern as
+    // the synthetic-wrapper-key path in `selectArrayStyle`.
+    // Limitation #4.
+    const arrayStyle =
+      array.length === 0 ? 'PIPES' : this.selectArrayStyle(key, context);
     const lineFeatures = this.analyzeLineFeatures(key, array, context);
     const prefix = lineFeatures.containsPrime ? '!' : '';
     // Quote the key if needed so the lexer can recover it cleanly.
@@ -711,11 +721,23 @@ export class RomlConverter {
     // COLLECTIONS keys go through `selectArrayStyle`, not this
     // function, so they keep their existing PIPES-or-other routing.
     const semanticStyle = this.getSemanticStyle(key);
+    // The lexer's `analyzeLineStructure` does a separator scan
+    // before the BRACKETS fallback, so a STATUS-keyed scalar
+    // (which routes to BRACKETS) containing one of `=:~#%$^+`
+    // would be mis-classified as an EQUALS-family KV line
+    // (e.g. `working<^>` reads as `working<` = `>`). Skip the
+    // BRACKETS override in that case and let the value-type
+    // branches pick a non-BRACKETS shape that the lexer's
+    // first-separator-wins scan handles correctly. Same shape
+    // family as the COLLECTIONS-PIPES skip in #13.
+    const valueHasKVSeparator =
+      typeof value === 'string' && /[=:~#%$^+]/.test(value);
     if (
       semanticStyle &&
       !isEvenLine &&
       valueType === 'string' &&
-      semanticStyle !== 'PIPES'
+      semanticStyle !== 'PIPES' &&
+      !(semanticStyle === 'BRACKETS' && valueHasKVSeparator)
     ) {
       return SYNTAX_STYLES[semanticStyle];
     }

--- a/src/RomlConverter.ts
+++ b/src/RomlConverter.ts
@@ -730,14 +730,28 @@ export class RomlConverter {
     // branches pick a non-BRACKETS shape that the lexer's
     // first-separator-wins scan handles correctly. Same shape
     // family as the COLLECTIONS-PIPES skip in #13.
+    //
+    // Only skip when the value would emit UNQUOTED. If
+    // `lineFeatures.needsQuotes` is true (set by
+    // `isAmbiguousString`), the BRACKETS template wraps the
+    // value in `"..."`, and the lexer's
+    // `findSeparatorOutsideQuotes` skips matches inside quotes —
+    // so the override is safe to apply. This minimises wire-
+    // format changes for already-ambiguous values that were
+    // round-tripping cleanly via the quoted form. (Copilot
+    // review refinement on PR #40.)
     const valueHasKVSeparator =
       typeof value === 'string' && /[=:~#%$^+]/.test(value);
+    const bracketsWouldMisparse =
+      semanticStyle === 'BRACKETS' &&
+      valueHasKVSeparator &&
+      !lineFeatures.needsQuotes;
     if (
       semanticStyle &&
       !isEvenLine &&
       valueType === 'string' &&
       semanticStyle !== 'PIPES' &&
-      !(semanticStyle === 'BRACKETS' && valueHasKVSeparator)
+      !bracketsWouldMisparse
     ) {
       return SYNTAX_STYLES[semanticStyle];
     }

--- a/src/__tests__/EmptyArrays.test.ts
+++ b/src/__tests__/EmptyArrays.test.ts
@@ -86,4 +86,96 @@ describe('Empty primitive arrays (limitation #4)', () => {
       expect(roundTrip({ x: ['only'] })).toEqual({ x: ['only'] });
     });
   });
+
+  describe('companion fix: `__proto__` as a value-object key (Copilot review)', () => {
+    // Pre-fix, `RomlParser.objectNodeToData` used
+    // `result[key] = value` which triggers the inherited
+    // prototype setter for `__proto__` (silently rejects the
+    // non-object write). Switched to `Object.defineProperty` so
+    // user-supplied keys become true own properties.
+
+    it('round-trips `__proto__` as a key with a string value', () => {
+      // Build with defineProperty so `__proto__` is an own enumerable
+      // property — fast-check constructs objects this way, but a
+      // JS object literal `{__proto__: " "}` would set the prototype
+      // instead.
+      const inner: Record<string, unknown> = {};
+      Object.defineProperty(inner, '__proto__', {
+        value: ' ',
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+      const input = { outer: inner };
+      const round = roundTrip(input) as { outer: Record<string, unknown> };
+      expect(Object.prototype.hasOwnProperty.call(round.outer, '__proto__')).toBe(true);
+      expect(round.outer.__proto__).toBe(' ');
+    });
+
+    it('round-trips a top-level `__proto__` key', () => {
+      const input: Record<string, unknown> = {};
+      Object.defineProperty(input, '__proto__', {
+        value: 'val',
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+      const round = roundTrip(input) as Record<string, unknown>;
+      expect(Object.prototype.hasOwnProperty.call(round, '__proto__')).toBe(true);
+      expect(round.__proto__).toBe('val');
+    });
+  });
+
+  describe('companion fix: STATUS-keyed scalars with KV-separator chars (Copilot review)', () => {
+    // STATUS-category keys route to BRACKETS for scalar string
+    // values (`working<value>`), but the lexer's
+    // `analyzeLineStructure` runs the KV-separator scan before
+    // the BRACKETS fallback. Values containing `=:~#%$^+` get
+    // mis-classified as an EQUALS-family KV line. Fix: skip the
+    // STATUS→BRACKETS override for those values (gated on
+    // `!needsQuotes` so already-quoted values still take the
+    // semantic override).
+
+    it('round-trips a STATUS-keyed value containing `^`', () => {
+      expect(roundTrip({ working: '^' })).toEqual({ working: '^' });
+    });
+
+    it('round-trips a STATUS-keyed value containing `~`', () => {
+      expect(roundTrip({ working: '~' })).toEqual({ working: '~' });
+    });
+
+    it('round-trips a STATUS-keyed value containing `#`', () => {
+      expect(roundTrip({ working: '#' })).toEqual({ working: '#' });
+    });
+
+    it('round-trips a STATUS-keyed value containing `=`', () => {
+      expect(roundTrip({ working: '=' })).toEqual({ working: '=' });
+    });
+
+    it('round-trips a STATUS-keyed value containing `:`', () => {
+      expect(roundTrip({ working: ':' })).toEqual({ working: ':' });
+    });
+
+    it('round-trips a STATUS-keyed value with separator in the middle', () => {
+      expect(roundTrip({ working: 'a^b' })).toEqual({ working: 'a^b' });
+    });
+
+    it('regression: STATUS-keyed value WITHOUT separator still uses BRACKETS', () => {
+      // `working` is the STATUS key, value `online` has no
+      // KV-separator, so the override should still apply and
+      // emit BRACKETS shape `working<online>`.
+      const input = { working: 'online' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+
+    it('regression: STATUS-keyed value with newline still uses BRACKETS (via QUOTED-inside-BRACKETS)', () => {
+      // `\n` triggers `isAmbiguousString` → `needsQuotes`. The
+      // gate's `!needsQuotes` clause keeps the BRACKETS
+      // override applied, and the value is wrapped in `"..."`
+      // — separator chars inside quotes are safely ignored by
+      // the lexer.
+      const input = { working: 'a\nb' };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
 });

--- a/src/__tests__/EmptyArrays.test.ts
+++ b/src/__tests__/EmptyArrays.test.ts
@@ -1,0 +1,89 @@
+import { RomlFile } from '../file/RomlFile';
+
+describe('Empty primitive arrays (limitation #4)', () => {
+  // Regression for fuzz limitation #4.
+  //
+  // PIPES emits empty arrays as `key||||` and the lexer
+  // correctly returns `[]`. The other three inline-array styles
+  // didn't:
+  //
+  //   BRACKETS    : encoder emitted `key` (no items), the lexer
+  //                  dropped the line entirely.
+  //   JSON_STYLE  : encoder emitted `key[]`, the lexer required
+  //                  `,` in content and the line fell through.
+  //   COLON_DELIM : encoder emitted `key:`, the lexer's
+  //                  COLON-array gate (`remainder.includes(':')`)
+  //                  failed and the line was parsed as a scalar
+  //                  KV-COLON with empty value.
+  //
+  // Fix: special-case `array.length === 0` in `convertArray` to
+  // route through the PIPES emitter regardless of the key's
+  // hash. PIPES already handles arity-0 correctly via its
+  // existing `key||||` shape, and the encoder already special-
+  // cases the synthetic-wrapper keys to PIPES in the same way
+  // (`selectArrayStyle`'s `isSyntheticWrapperKey` shortcut).
+
+  function roundTrip(input: unknown): unknown {
+    return RomlFile.romlToJson(RomlFile.jsonToRoml(input));
+  }
+
+  describe('empty arrays under each hash bucket', () => {
+    it('round-trips an empty array under key `x` (hash bucket 0, PIPES)', () => {
+      expect(roundTrip({ x: [] })).toEqual({ x: [] });
+    });
+
+    it('round-trips an empty array under key `elements` (hash bucket 1, BRACKETS)', () => {
+      expect(roundTrip({ elements: [] })).toEqual({ elements: [] });
+    });
+
+    it('round-trips an empty array under key `abc` (hash bucket 2, JSON_STYLE)', () => {
+      expect(roundTrip({ abc: [] })).toEqual({ abc: [] });
+    });
+
+    it('round-trips an empty array under key `id` (hash bucket 3, COLON_DELIM)', () => {
+      expect(roundTrip({ id: [] })).toEqual({ id: [] });
+    });
+  });
+
+  describe('top-level empty array (synthetic-wrapper PIPES, no-regression)', () => {
+    it('round-trips a top-level empty array', () => {
+      expect(roundTrip([])).toEqual([]);
+    });
+  });
+
+  describe('multiple empty arrays in one object', () => {
+    it('round-trips a mix of empty-array keys across hash buckets', () => {
+      expect(
+        roundTrip({ x: [], elements: [], abc: [], id: [] })
+      ).toEqual({ x: [], elements: [], abc: [], id: [] });
+    });
+
+    it('round-trips an empty array alongside a non-empty array', () => {
+      expect(
+        roundTrip({ x: [], y: ['a'] })
+      ).toEqual({ x: [], y: ['a'] });
+    });
+  });
+
+  describe('regression: non-empty arrays still pick by hash', () => {
+    it('regression: 2-element under PIPES key', () => {
+      expect(roundTrip({ x: ['a', 'b'] })).toEqual({ x: ['a', 'b'] });
+    });
+
+    it('regression: 2-element under BRACKETS key', () => {
+      expect(roundTrip({ elements: ['a', 'b'] })).toEqual({ elements: ['a', 'b'] });
+    });
+
+    it('regression: 2-element under JSON_STYLE key', () => {
+      expect(roundTrip({ abc: ['a', 'b'] })).toEqual({ abc: ['a', 'b'] });
+    });
+
+    it('regression: 2-element under COLON_DELIM key', () => {
+      expect(roundTrip({ id: ['a', 'b'] })).toEqual({ id: ['a', 'b'] });
+    });
+
+    it('regression: 1-element under PIPES key (arity-1 marker)', () => {
+      expect(roundTrip({ x: ['only'] })).toEqual({ x: ['only'] });
+    });
+  });
+});

--- a/src/__tests__/RoundTripFuzz.test.ts
+++ b/src/__tests__/RoundTripFuzz.test.ts
@@ -185,9 +185,11 @@ describe('Round-trip property tests (fast-check)', () => {
  *     PIPES filter already drops empty items; JSON_STYLE's
  *     walker already drops empty `current`; COLON_DELIM
  *     learned to drop a single trailing empty token.)
- *  4. Empty arrays in BRACKETS / JSON_STYLE / COLON_DELIM styles —
- *     only PIPES emits a recoverable empty-array form; the other
- *     three reduce to a key-only line that the lexer drops.
+ *  4. (Resolved — `convertArray` now forces PIPES regardless of
+ *     `selectArrayStyle`'s hash output when the array is empty.
+ *     PIPES is the only inline style with a recoverable empty
+ *     form (`key||||`). Mirrors the synthetic-wrapper-key
+ *     shortcut already in `selectArrayStyle`.)
  *  5. (Resolved — single-bracket parsing now lives only in
  *     `analyzeLineStructure`'s fallback path, runs after the regular
  *     separator scan, and uses `findSeparatorOutsideQuotes` for the
@@ -269,18 +271,18 @@ describe('Round-trip property tests (fast-check)', () => {
  * `isAmbiguousString`) plus the lexer's quote-aware PIPES content
  * split (`splitOutsideQuotes`).
  */
-function arrayItemsHaveKnownLimitation(arr: unknown[]): boolean {
-  // (3) Resolved — every inline-array style now emits an arity-1
-  // marker (PIPES trailing `||`, JSON_STYLE trailing `,`,
-  // COLON_DELIM trailing `:`, BRACKETS' pre-existing `<>`), so
-  // single-element primitive arrays round-trip without unwrapping
-  // to scalar.
-  // (4) Empty arrays of any depth (still open).
-  if (arr.length === 0) return true;
-  // (14) Resolved — every inline-array separator-char now
-  // round-trips: `|` (#12, #36), `\` (#11), `"` (#36 PIPES,
-  // #37 BRACKETS, this PR for COLON_DELIM), `>`/`<` (#9), `:`
-  // (this PR). The ledger is empty.
+function arrayItemsHaveKnownLimitation(_arr: unknown[]): boolean {
+  // All array-item-shape limitations are resolved:
+  //   #3  arity-1 markers per style (PIPES `||`, JSON_STYLE `,`,
+  //       COLON_DELIM `:`, BRACKETS' pre-existing `<>`).
+  //   #4  empty arrays forced through PIPES (this PR).
+  //   #9  BRACKETS `>`/`<` quoted.
+  //   #11 JSON_STYLE escape via `JSON.parse`.
+  //   #12 PIPES `|`/`||` via quote-aware split.
+  //   #14 every inline-array separator-char (`:`, `>`, `"`, `\`,
+  //       `|`) round-trips.
+  // Function kept (rather than inlined `return false`) so future
+  // limitations can re-add screens here without restructuring.
   return false;
 }
 
@@ -307,10 +309,11 @@ function hasKnownLimitation(input: unknown): boolean {
     //      style emits an arity-1 marker; single-element primitive
     //      arrays round-trip cleanly.
 
-    // (4) Empty arrays of any depth — the encoder's hash-based array
-    // style selection picks BRACKETS / JSON_STYLE / COLON_DELIM about
-    // 75% of the time, all of which lose empty-array fidelity.
-    if (Array.isArray(value) && value.length === 0) return true;
+    // (4) Resolved — empty arrays now force PIPES in
+    //      `convertArray` regardless of the key's hash, since only
+    //      PIPES has a recoverable empty-form (`key||||`). Same
+    //      shortcut pattern as the synthetic-wrapper-key path in
+    //      `selectArrayStyle`.
 
     // (5) and (6) resolved; no constraints needed.
 

--- a/src/parser/RomlParser.ts
+++ b/src/parser/RomlParser.ts
@@ -394,18 +394,38 @@ export class RomlParser {
       }
     };
 
+    // Use `Object.defineProperty` rather than `result[key] = value`
+    // so user-supplied keys like `__proto__` become own properties
+    // of `result` instead of triggering the inherited
+    // prototype-setter (which would silently drop the assignment,
+    // since `__proto__`'s setter rejects non-object values). Same
+    // concern for `constructor` etc., but `__proto__` is the only
+    // one that actively swallows the write. `Object.defineProperty`
+    // bypasses the prototype chain entirely and creates a true
+    // own property regardless of key name. (Fuzz-surfaced when the
+    // #4 empty-array screen was dropped — input `{"":{"__proto__":
+    // " "}}` was round-tripping as `{"":{}}`.)
+    const setKey = (key: string, value: unknown) => {
+      Object.defineProperty(result, key, {
+        value,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+    };
+
     for (const prop of node.properties) {
       recordKey(prop.key, prop.lineNumber);
-      result[prop.key] = prop.value;
+      setKey(prop.key, prop.value);
     }
 
     for (const child of node.children) {
       if (child.type === 'object') {
         recordKey(child.key!, child.lineNumber);
-        result[child.key!] = this.objectNodeToData(child);
+        setKey(child.key!, this.objectNodeToData(child));
       } else if (child.type === 'array') {
         recordKey(child.key, child.lineNumber);
-        result[child.key] = this.arrayNodeToData(child);
+        setKey(child.key, this.arrayNodeToData(child));
       }
     }
 


### PR DESCRIPTION
## Summary

Limitation #4: empty arrays in BRACKETS / JSON_STYLE / COLON_DELIM had no recoverable wire form. Only PIPES emits `key||||` which the lexer round-trips as `[]`.

Fix (one line in `convertArray`): when `array.length === 0`, bypass `selectArrayStyle`'s hash-based pick and route directly through PIPES. Same shortcut pattern as the existing `isSyntheticWrapperKey` short-circuit.

This empties the inline-array fuzz screens entirely. With the limitation gates removed, fast-check surfaced two pre-existing bugs that the screen sequencing had been hiding:

### Companion fix 1: `__proto__` key stripped

`RomlParser.objectNodeToData` used `result[key] = value`, which triggers the inherited prototype setter for `__proto__` and silently rejects the non-object write. Switched to `Object.defineProperty` for all key writes so user-supplied keys become true own properties regardless of name.

### Companion fix 2: STATUS-keyed scalar with KV-separator

`working<^>` (and similar STATUS-keyed scalars containing `=:~#%$^+`) got mangled because the STATUS→BRACKETS semantic override produces `key<value>`, but the lexer's `analyzeLineStructure` runs the KV-separator scan before the BRACKETS fallback. Added a `valueHasKVSeparator` gate in `selectSyntax` that skips the STATUS→BRACKETS override for these values — same pattern as the COLLECTIONS→PIPES skip from #13.

## Test plan

- [x] `npm test` — 539 tests pass (12 new in `EmptyArrays.test.ts`), up from 527.
- [x] `npm run lint` — clean.
- [x] `npm run build` — TypeScript clean.
- [x] Pinned fuzz (`seed: 20260507, numRuns: 100`) runs **unconstrained** and green. `hasKnownLimitation` is now effectively a no-op (kept as a placeholder).
- [x] CLI smoke: `{x:[]}`, `{elements:[]}`, `{abc:[]}`, `{id:[]}`, `[]`, `{working:"^"}`, `{"":{"__proto__":" "}}` all round-trip identically.

**After this PR, the inline-array fuzz limitations are fully closed. The property test runs unconstrained — any new counterexample is a real regression.**

BC break: encoder output changes for empty arrays under non-PIPES hash buckets and for STATUS-keyed scalars containing KV-separator chars. Pre-fix output was unrecoverable in both cases, so no valid round-tripping document changes shape.

https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV)_