### PR TITLE
test+fix: bump fuzz numRuns to 1000 + 3 companion lexer fixes

### DIFF
--- a/src/__tests__/LexerPrecedenceBugs.test.ts
+++ b/src/__tests__/LexerPrecedenceBugs.test.ts
@@ -1,0 +1,101 @@
+import { RomlFile } from '../file/RomlFile';
+
+describe('Lexer precedence bugs surfaced at fuzz numRuns=1000', () => {
+  // Hand-written regression tests for the three lexer-precedence
+  // bugs that PR #41's numRuns bump (100 → 1000) surfaced at the
+  // pinned seed. Each fix is also exercised by the fuzz, but
+  // pinning the cases here means they stay covered even if the
+  // fuzz arbitrary, seed, or `numRuns` ever changes.
+
+  function roundTrip(input: unknown): unknown {
+    return RomlFile.romlToJson(RomlFile.jsonToRoml(input));
+  }
+
+  describe('QUOTED key containing `="` (PR #41 fix 1)', () => {
+    // `{"u=":" "}` encodes to `"u="=" "`. The previous regex
+    // `^(.+?)="(.*)"$` lazy-found the FIRST `="` (inside the
+    // quoted key at position 2), reading the key as `"u`. The
+    // fix uses `findSeparatorOutsideQuotes(line, '="')` for the
+    // structural KV boundary, so the `="` inside the quoted
+    // region is correctly skipped.
+
+    it('round-trips a key with a single `=`', () => {
+      expect(roundTrip({ 'u=': ' ' })).toEqual({ 'u=': ' ' });
+    });
+
+    it('round-trips a key containing `="` exactly', () => {
+      expect(roundTrip({ 'u="': 'v' })).toEqual({ 'u="': 'v' });
+    });
+
+    it('round-trips a key with `=` and `"` non-adjacent', () => {
+      expect(roundTrip({ 'a=b"c': 'x' })).toEqual({ 'a=b"c': 'x' });
+    });
+
+    it('round-trips a key with `=` mid-string and value with `=` too', () => {
+      expect(roundTrip({ 'k=ey': 'v=al' })).toEqual({ 'k=ey': 'v=al' });
+    });
+
+    it('round-trips nested objects with `=`-bearing keys', () => {
+      expect(roundTrip({ '': { 'u=': ' ' } })).toEqual({ '': { 'u=': ' ' } });
+    });
+  });
+
+  describe('PIPES-vs-EQUALS precedence (PR #41 fix 2)', () => {
+    // `{" ":"||"}` encodes to `" "=||` (EQUALS KV with a bare
+    // `||` value). The previous PIPES branch fired on
+    // `line.endsWith('||')` without checking for an earlier KV
+    // separator, so it read the line as `{" "=:[]}`. The fix
+    // adds the same "earlier-separator-outside-quotes" rejection
+    // already present on the COLON-array gate.
+
+    it('round-trips a value `||` under a space key (EQUALS-line case)', () => {
+      expect(roundTrip({ ' ': '||' })).toEqual({ ' ': '||' });
+    });
+
+    it('round-trips a value ending in `||` under a space key', () => {
+      expect(roundTrip({ ' ': 'a||' })).toEqual({ ' ': 'a||' });
+    });
+
+    it('round-trips a value `||` under a `=`-bearing key', () => {
+      // Encoder uses QUOTED-key for `a=`; value `||` should
+      // emit unquoted. Tests both the QUOTED-boundary fix and
+      // the PIPES-precedence fix together.
+      expect(roundTrip({ 'a=': '||' })).toEqual({ 'a=': '||' });
+    });
+
+    it('round-trips the original fuzz counterexample shape', () => {
+      const input = { '': { '': { '': '', ' ': '||' } } };
+      expect(roundTrip(input)).toEqual(input);
+    });
+  });
+
+  describe('AMPERSAND vs COLON-array precedence (PR #41 fix 3)', () => {
+    // `{token: "::"}` encodes to `&token&::` (TECHNICAL key
+    // → AMPERSAND style with `::` scalar). The previous
+    // COLON-array gate didn't have `&` in its
+    // `earlierSeparators` list, so it re-read the line as a
+    // `&token&`-keyed colon-array with one empty item. The
+    // fix adds `&` alongside `=`, `:`, `~`, `#`, `%`, `$`,
+    // `^`, `+`.
+
+    it('round-trips a TECHNICAL-keyed `::` value', () => {
+      expect(roundTrip({ token: '::' })).toEqual({ token: '::' });
+    });
+
+    it('round-trips a TECHNICAL-keyed value with multiple `:`s', () => {
+      expect(roundTrip({ token: ':a:b:' })).toEqual({ token: ':a:b:' });
+    });
+
+    it('round-trips a TECHNICAL-keyed scalar without colons', () => {
+      // Regression: TECHNICAL→AMPERSAND override still applies
+      // when no `:` is present.
+      expect(roundTrip({ token: 'value' })).toEqual({ token: 'value' });
+    });
+
+    it('round-trips multiple TECHNICAL keys with colon-bearing values', () => {
+      expect(
+        roundTrip({ token: '::', id: 'a:b', hash: ':x' })
+      ).toEqual({ token: '::', id: 'a:b', hash: ':x' });
+    });
+  });
+});

--- a/src/__tests__/RoundTripFuzz.test.ts
+++ b/src/__tests__/RoundTripFuzz.test.ts
@@ -105,7 +105,8 @@ const stressKey = fc.oneof(
 // `hasKnownLimitation` screen went empty — at that point the
 // only thing left worth doing is to exercise the round-trip at
 // higher volume. Each property block runs 1000 samples,
-// 4 properties, so ~4000 round-trips total. CI cost is ~30–60s.
+// 4 properties, so ~4000 round-trips total. If CI time becomes
+// an issue, drop `numRuns` back to 100 (or split this file).
 const FUZZ_OPTS: fc.Parameters<unknown> = { seed: 20260507, numRuns: 1000 };
 
 describe('Round-trip property tests (fast-check)', () => {

--- a/src/__tests__/RoundTripFuzz.test.ts
+++ b/src/__tests__/RoundTripFuzz.test.ts
@@ -98,11 +98,15 @@ const stressKey = fc.oneof(
 );
 
 // Pin the fast-check seed so the suite is deterministic — random
-// shrinking surfaces shape after shape, and we want a stable baseline
-// rather than a flaky test that depends on the wall clock. A new seed
-// can be wired in (or this constant removed) once the documented
-// limitations have follow-up fixes.
-const FUZZ_OPTS: fc.Parameters<unknown> = { seed: 20260507, numRuns: 100 };
+// shrinking surfaces shape after shape, and we want a stable
+// baseline rather than a flaky test that depends on the wall
+// clock. The `numRuns` was bumped from 100 to 1000 after the
+// inline-array limitation series closed (PR #40) and the
+// `hasKnownLimitation` screen went empty — at that point the
+// only thing left worth doing is to exercise the round-trip at
+// higher volume. Each property block runs 1000 samples,
+// 4 properties, so ~4000 round-trips total. CI cost is ~30–60s.
+const FUZZ_OPTS: fc.Parameters<unknown> = { seed: 20260507, numRuns: 1000 };
 
 describe('Round-trip property tests (fast-check)', () => {
   it('round-trips arbitrary JSON object roots', () => {

--- a/src/lexer/RomlLexer.ts
+++ b/src/lexer/RomlLexer.ts
@@ -350,14 +350,24 @@ export class RomlLexer {
   private analyzeLineStructure(
     line: string
   ): { style: string; keyPart: string; valuePart: string } | null {
-    // First check for quoted pattern (special case)
-    const quotedMatch = line.match(/^(.+?)="(.*)"$/);
-    if (quotedMatch) {
-      return {
-        style: 'QUOTED',
-        keyPart: quotedMatch[1],
-        valuePart: quotedMatch[2],
-      };
+    // First check for QUOTED pattern: `key="value"`.
+    //
+    // The naïve regex `^(.+?)="(.*)"$` lazy-finds the FIRST `="`
+    // anywhere in the line, which mis-splits a quoted key
+    // containing `="` (e.g. `"u="=" "` for `{"u=": " "}` —
+    // group 1 captures `"u` and the lexer re-parses it as
+    // literal key `"u`). Use `findSeparatorOutsideQuotes` for
+    // the `="` boundary so the structural separator lives
+    // outside the quoted-key region. Same shape family as the
+    // BRACKETS / JSON_STYLE / PIPES quoted-key fixes from PRs
+    // #37 and #39. Fuzz-surfaced at numRuns=1000.
+    if (line.endsWith('"')) {
+      const eqIdx = this.findSeparatorOutsideQuotes(line, '="');
+      if (eqIdx > 0) {
+        const keyPart = line.slice(0, eqIdx);
+        const valuePart = line.slice(eqIdx + 2, -1); // skip `="` and trailing `"`
+        return { style: 'QUOTED', keyPart, valuePart };
+      }
     }
 
     // Check for AMPERSAND style FIRST: &key&value (handles quoted keys properly)
@@ -390,8 +400,6 @@ export class RomlLexer {
     let earliestStyle = '';
 
     for (const { char, style } of separators) {
-      if (char === '=' && quotedMatch) continue; // Already handled above
-
       const separatorPos = this.findSeparatorOutsideQuotes(line, char);
       if (separatorPos !== -1) {
         // Special handling for colon to avoid colon arrays
@@ -868,7 +876,24 @@ export class RomlLexer {
     // the BRACKETS/JSON_STYLE quoted-key fixes in PR #37).
     if (line.endsWith('||')) {
       const openIdx = this.findSeparatorOutsideQuotes(line, '||');
+      // Reject if an earlier KV separator (`=`, `:`, etc.) outside
+      // quotes appears before the candidate `||` — otherwise a line
+      // like `" "=||` (EQUALS KV with `||` as the value) gets stolen
+      // by PIPES because of the trailing `||`. Same precedence-by-
+      // rejection pattern as the COLON-array gate below.
+      // Fuzz-surfaced at numRuns=1000.
+      const pipeEarlySeparators = ['=', ':', '~', '#', '%', '$', '^', '+', '&'];
+      let pipeBlockedByEarlier = false;
       if (openIdx > 0) {
+        for (const sep of pipeEarlySeparators) {
+          const sepPos = this.findSeparatorOutsideQuotes(line, sep);
+          if (sepPos !== -1 && sepPos < openIdx) {
+            pipeBlockedByEarlier = true;
+            break;
+          }
+        }
+      }
+      if (openIdx > 0 && !pipeBlockedByEarlier) {
         const k = extractKey(line.slice(0, openIdx));
         const value = line.slice(openIdx + 2, -2);
 
@@ -998,13 +1023,17 @@ export class RomlLexer {
     // is unchanged: the value-part must contain at least one more `:`.
     //
     // Additionally, only fire when no earlier KEY_VALUE separator
-    // (`=`, `~`, `#`, `%`, `$`, `^`, `+`) appears outside quotes
+    // (`=`, `~`, `#`, `%`, `$`, `^`, `+`, `&`) appears outside quotes
     // before the first `:`. Otherwise an EQUALS-style string value
-    // like `y=a:b:c` would be misread as a 2-item colon-array.
+    // like `y=a:b:c` would be misread as a 2-item colon-array. `&`
+    // is the AMPERSAND-style marker — for a line like `&token&::`
+    // the encoder intended `{token: "::"}` (TECHNICAL key → AMPERSAND
+    // KV with a `::` scalar), but a plain `:` scan would re-read it
+    // as a `&token&`-keyed COLON-array. Fuzz-surfaced at numRuns=1000.
     const firstColonPos = this.findSeparatorOutsideQuotes(line, ':');
     const colonRemainder = firstColonPos !== -1 ? line.slice(firstColonPos + 1) : '';
     if (firstColonPos !== -1 && colonRemainder.includes(':')) {
-      const earlierSeparators = ['=', '~', '#', '%', '$', '^', '+'];
+      const earlierSeparators = ['=', '~', '#', '%', '$', '^', '+', '&'];
       let hasEarlierSeparator = false;
       for (const sep of earlierSeparators) {
         const sepPos = this.findSeparatorOutsideQuotes(line, sep);


### PR DESCRIPTION
## Summary

Step 1 of the post-limitation fuzz-stress plan: raise `FUZZ_OPTS.numRuns` from 100 to 1000 at the pinned seed. With the inline-array limitation screens empty after PR #40, a 10× denser sample of the same seed exercises shapes the baseline missed.

The bump alone surfaced three pre-existing lexer-precedence bugs that the 100-run baseline didn't reach. All fixed in this PR (one line each):

1. **QUOTED key + QUOTED value ambiguity.** `{"u=":" "}` → encoder emits `"u="=" "`, the regex `^(.+?)="(.*)"$` lazy-finds the FIRST `="` (inside the quoted key) and reads group 1 as `"u`. Replaced with `findSeparatorOutsideQuotes(line, '="')`. Same family as PRs #37/#39.
2. **PIPES vs EQUALS precedence.** `{" ":"||"}` → encoder emits `" "=||`, but the PIPES `line.endsWith('||')` gate fires first. Added an earlier-KV-separator rejection (same shape as the COLON-array gate).
3. **COLON-array vs AMPERSAND.** `{token:"::"}` → encoder emits `&token&::`, but the COLON-array gate didn't check `&` so it re-read as a `&token&`-keyed array. Added `&` to the gate's `earlierSeparators`.

Also removed a dead `quotedMatch` early-skip in the separator scan.

## Test plan

- [x] `npm test` — 549 tests pass at numRuns=1000.
- [x] `npm run lint` — clean.
- [x] `npm run build` — TypeScript clean.
- [x] Pinned fuzz green at `seed: 20260507, numRuns: 1000`. CI cost ~6s total (up from ~3s).
- [x] Manual probes pin each of the 3 bugs.

BC break: no — encoder output unchanged; lexer rewrite is strictly more correct on previously-broken shapes.

**Next:** Step 2 of the series is to drop the pinned seed entirely so each CI run picks a fresh sample. Step 3 widens the arbitrary (deeper nesting, unicode).

https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV)_