### PR TITLE
test+fix: drop pinned fuzz seed + multi-bracket gate fix

### DIFF
--- a/src/__tests__/LexerPrecedenceBugs.test.ts
+++ b/src/__tests__/LexerPrecedenceBugs.test.ts
@@ -69,6 +69,36 @@ describe('Lexer precedence bugs surfaced at fuzz numRuns=1000', () => {
     });
   });
 
+  describe('Multi-bracket-array gate vs quoted-key `><` (PR #43 fix)', () => {
+    // `{"><": false}` encodes to `"><"<false>` (BRACKETS KV with
+    // a quoted key + boolean value on odd lines). The previous
+    // multi-bracket-array gate `line.includes('><')` fired
+    // because the QUOTED key contains `><`, mis-classifying the
+    // line as a 1-element BRACKETS array. The fix uses
+    // `findSeparatorOutsideQuotes(line, '><')` so the `><`
+    // inside the quoted region is correctly skipped.
+
+    it('round-trips a `><`-keyed boolean false', () => {
+      expect(roundTrip({ '><': false })).toEqual({ '><': false });
+    });
+
+    it('round-trips a `><`-keyed boolean true', () => {
+      expect(roundTrip({ '><': true })).toEqual({ '><': true });
+    });
+
+    it('round-trips a mid-key `><`', () => {
+      expect(roundTrip({ 'a><b': false })).toEqual({ 'a><b': false });
+    });
+
+    it('regression: 2-element BRACKETS array still classifies as array', () => {
+      expect(roundTrip({ elements: ['a', 'b'] })).toEqual({ elements: ['a', 'b'] });
+    });
+
+    it('regression: arity-1 BRACKETS array still classifies as array', () => {
+      expect(roundTrip({ elements: ['only'] })).toEqual({ elements: ['only'] });
+    });
+  });
+
   describe('AMPERSAND vs COLON-array precedence (PR #41 fix 3)', () => {
     // `{token: "::"}` encodes to `&token&::` (TECHNICAL key
     // → AMPERSAND style with `::` scalar). The previous

--- a/src/__tests__/RoundTripFuzz.test.ts
+++ b/src/__tests__/RoundTripFuzz.test.ts
@@ -97,17 +97,16 @@ const stressKey = fc.oneof(
   )
 );
 
-// Pin the fast-check seed so the suite is deterministic — random
-// shrinking surfaces shape after shape, and we want a stable
-// baseline rather than a flaky test that depends on the wall
-// clock. The `numRuns` was bumped from 100 to 1000 after the
-// inline-array limitation series closed (PR #40) and the
-// `hasKnownLimitation` screen went empty — at that point the
-// only thing left worth doing is to exercise the round-trip at
-// higher volume. Each property block runs 1000 samples,
-// 4 properties, so ~4000 round-trips total. If CI time becomes
-// an issue, drop `numRuns` back to 100 (or split this file).
-const FUZZ_OPTS: fc.Parameters<unknown> = { seed: 20260507, numRuns: 1000 };
+// `numRuns: 1000` per property at the wall-clock default seed.
+// The pinned seed (`20260507`) served as a stable baseline while
+// the limitation series closed; with the screens now empty
+// (post PR #40) the contract is robust enough to test against
+// arbitrary samples. Each CI run picks a fresh seed; fast-check
+// prints the seed on failure so any counterexample is
+// reproducible (paste it into `FUZZ_OPTS` and re-run).
+// If CI time becomes an issue, drop `numRuns` back to 100 (or
+// split this file).
+const FUZZ_OPTS: fc.Parameters<unknown> = { numRuns: 1000 };
 
 describe('Round-trip property tests (fast-check)', () => {
   it('round-trips arbitrary JSON object roots', () => {

--- a/src/lexer/RomlLexer.ts
+++ b/src/lexer/RomlLexer.ts
@@ -797,8 +797,19 @@ export class RomlLexer {
     // — a quoted key containing `<` (e.g. `"<-"<false><null>`) has
     // its first `<` inside the quoted region, which is part of
     // the key, not a structural item-start marker.
+    //
+    // The `><`-gate also needs to ignore matches inside a quoted
+    // key region. A KV BRACKETS line with a quoted-key containing
+    // `><` (e.g. `"><"<false>` for `{"><":false}`) has the only
+    // `><` byte sequence INSIDE the quoted key, not between two
+    // structural items. Without the quote-aware check it'd be
+    // mis-classified as a multi-bracket array. Surfaced by
+    // dropping the pinned fuzz seed in PR #43.
     const multiBracketMatch = line.match(/^(.+?)(<.+>)+$/);
-    if (multiBracketMatch && line.includes('><')) {
+    if (
+      multiBracketMatch &&
+      this.findSeparatorOutsideQuotes(line, '><') !== -1
+    ) {
       const firstBracket = this.findSeparatorOutsideQuotes(line, '<');
       if (firstBracket <= 0) {
         // Either no `<` outside quotes, or the line starts with one


### PR DESCRIPTION
## Summary

Step 2 of the post-limitation fuzz-stress plan: remove `seed: 20260507` from `FUZZ_OPTS` so each CI run picks a fresh wall-clock seed. fast-check prints the seed on failure, so any counterexample is reproducible by pasting it back into `FUZZ_OPTS`.

The drop surfaced one pre-existing lexer bug that the pinned seed had been hiding:

**Multi-bracket-array gate vs quoted-key `><`.** For `{"><": false}` the encoder emits `"><"<false>` (BRACKETS KV with quoted key + boolean value on odd lines). The gate `line.includes('><')` fired because the QUOTED key bytes contained `><`, even though they were inside the quoted region — so the line was mis-classified as a multi-bracket array and the boolean got wrapped as a 1-element array. Fix: replace `line.includes('><')` with `findSeparatorOutsideQuotes(line, '><') !== -1`. Same family as the BRACKETS/JSON_STYLE/PIPES quoted-key fixes from previous PRs.

## Test plan

- [x] 20 consecutive runs of the fuzz file with random seeds — all pass.
- [x] `npm test` — 567 tests pass (5 new in `LexerPrecedenceBugs.test.ts`).
- [x] `npm run lint` — clean.
- [x] `npm run build` — TypeScript clean.

BC break: no — encoder output unchanged.

**Next step in the series:** widen the arbitrary (deeper nesting, unicode). That's an open-ended exploration likely to surface more bugs.

https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUQmsaUz2ieUbn5sGCdPRV)_